### PR TITLE
Bug fix in ZMQ.Context.CreateSocketPtr

### DIFF
--- a/clrzmq/Context.cs
+++ b/clrzmq/Context.cs
@@ -105,7 +105,7 @@ namespace ZMQ {
 
         internal IntPtr CreateSocketPtr(SocketType type) {
             IntPtr socket_ptr = C.zmq_socket(_ptr, (int)type);
-            if (_ptr == IntPtr.Zero)
+            if (socket_ptr == IntPtr.Zero)
                 throw new Exception();
             return socket_ptr;
         }


### PR DESCRIPTION
Error from C.zmq_socket is never checked - _ptr never equals IntPtr.Zero.
Returned socket_ptr must be checked instead.

if (_ptr == IntPtr.Zero)
... changed to:
if (socket_ptr == IntPtr.Zero)
