### PR TITLE
Modified clrzmq2 to support zmq3.0 in favor of zmq2.x

### DIFF
--- a/clrzmq/Context.cs
+++ b/clrzmq/Context.cs
@@ -3,6 +3,7 @@
     Copyright (c) 2010 Jeffrey Dik <s450r1@gmail.com>
     Copyright (c) 2010 Martin Sustrik <sustrik@250bpm.com>
     Copyright (c) 2010 Michael Compton <michael.compton@littleedge.co.uk>
+    Copyright (c) 2011 Calvin de Vries <devries.calvin@gmail.com>
 
     This file is part of clrzmq2.
 
@@ -31,7 +32,8 @@ using Mono.Posix;
 using Mono.Unix;
 #endif
 
-namespace ZMQ {
+namespace ZMQ
+{
 #if POSIX
     public static class SignalHandler {
         private static object _sync = new object();
@@ -63,7 +65,8 @@ namespace ZMQ {
     /// <summary>
     /// ZMQ Context
     /// </summary>
-    public class Context : IDisposable {
+    public class Context : IDisposable
+    {
         private static int _defaultIOThreads = 1;
         private IntPtr _ptr;
 
@@ -72,7 +75,8 @@ namespace ZMQ {
         /// Create ZMQ Context
         /// </summary>
         /// <param name="io_threads">Thread pool size</param>
-        public Context(int io_threads) {
+        public Context(int io_threads)
+        {
 #if POSIX
             SignalHandler.StartHandler();
 #endif
@@ -81,7 +85,8 @@ namespace ZMQ {
                 throw new Exception();
         }
 
-        public Context() {
+        public Context()
+        {
 #if POSIX
             SignalHandler.StartHandler();
 #endif
@@ -90,7 +95,8 @@ namespace ZMQ {
                 throw new Exception();
         }
 
-        ~Context() {
+        ~Context()
+        {
             Dispose(false);
         }
 
@@ -99,24 +105,29 @@ namespace ZMQ {
         /// </summary>
         /// <param name="type">Type of socket to be created</param>
         /// <returns>A new ZMQ socket</returns>
-        public Socket Socket(SocketType type) {
+        public Socket Socket(SocketType type)
+        {
             return new Socket(CreateSocketPtr(type));
         }
 
-        internal IntPtr CreateSocketPtr(SocketType type) {
+        internal IntPtr CreateSocketPtr(SocketType type)
+        {
             IntPtr socket_ptr = C.zmq_socket(_ptr, (int)type);
             if (_ptr == IntPtr.Zero)
                 throw new Exception();
             return socket_ptr;
         }
 
-        public void Dispose() {
+        public void Dispose()
+        {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing) {
-            if (_ptr != IntPtr.Zero) {
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_ptr != IntPtr.Zero)
+            {
                 int rc = C.zmq_term(_ptr);
                 _ptr = IntPtr.Zero;
                 if (rc != 0)
@@ -124,7 +135,8 @@ namespace ZMQ {
             }
         }
 
-        public static int DefaultIOThreads {
+        public static int DefaultIOThreads
+        {
             get { return _defaultIOThreads; }
             set { _defaultIOThreads = value; }
         }
@@ -133,9 +145,10 @@ namespace ZMQ {
         /// Polls the supplied items for events.
         /// </summary>
         /// <param name="items">Items to Poll</param>
-        /// <param name="timeout">Timeout(micro seconds)</param>
+        /// <param name="timeout">Timeout(milliseconds)</param>
         /// <returns>Number of Poll items with events</returns>
-        public int Poll(PollItem[] items, long timeout) {
+        public int Poll(PollItem[] items, long timeout)
+        {
             return Poller(items, timeout);
         }
 
@@ -144,7 +157,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="items">Items to Poll</param>
         /// <returns>Number of Poll items with events</returns>
-        public int Poll(PollItem[] items) {
+        public int Poll(PollItem[] items)
+        {
             return Poll(items, -1);
         }
 
@@ -153,40 +167,55 @@ namespace ZMQ {
         /// Polls the supplied items for events. Static method.
         /// </summary>
         /// <param name="items">Items to Poll</param>
-        /// <param name="timeout">Timeout(micro seconds)</param>
+        /// <param name="timeout">Timeout(milliseconds)</param>
         /// <returns>Number of Poll items with events</returns>
-        public static int Poller(PollItem[] items, long timeout) {
+        public static int Poller(PollItem[] items, long timeout)
+        {
             Stopwatch spentTimeout = new Stopwatch();
             int rc = -1;
-            if (timeout >= 0) {
+            if (timeout >= 0)
+            {
                 spentTimeout.Start();
             }
-            while (rc != 0) {
+            while (rc != 0)
+            {
                 ZMQPollItem[] zitems = new ZMQPollItem[items.Length];
                 int index = 0;
-                foreach (PollItem item in items) {
+                foreach (PollItem item in items)
+                {
                     item.ZMQPollItem.ResetRevents();
                     zitems[index] = item.ZMQPollItem;
                     index++;
                 }
                 rc = C.zmq_poll(zitems, items.Length, timeout);
-                if (rc > 0) {
-                    for (index = 0; index < items.Length; index++) {
+                if (rc > 0)
+                {
+                    for (index = 0; index < items.Length; index++)
+                    {
                         items[index].ZMQPollItem = zitems[index];
                         items[index].FireEvents();
                     }
                     break;
-                } else if (rc < 0) {
-                    if (ZMQ.C.zmq_errno() == 4) {
-                        if (spentTimeout.IsRunning) {
-                            long elapsed = spentTimeout.ElapsedMilliseconds * 1000;
-                            if (timeout < elapsed) {
+                }
+                else if (rc < 0)
+                {
+                    if (ZMQ.C.zmq_errno() == 4)
+                    {
+                        if (spentTimeout.IsRunning)
+                        {
+                            long elapsed = spentTimeout.ElapsedMilliseconds;
+                            if (timeout < elapsed)
+                            {
                                 break;
-                            } else {
+                            }
+                            else
+                            {
                                 timeout -= elapsed;
                                 continue;
                             }
-                        } else {
+                        }
+                        else
+                        {
                             continue;
                         }
                     }
@@ -202,15 +231,18 @@ namespace ZMQ {
         /// </summary>
         /// <param name="items">Items to Poll</param>
         /// <returns>Number of Poll items with events</returns>
-        public static int Poller(PollItem[] items) {
+        public static int Poller(PollItem[] items)
+        {
             return Poller(items, -1);
         }
 
-        public static int Poller(params Socket[] sockets) {
+        public static int Poller(params Socket[] sockets)
+        {
             return Poller(new List<Socket>(sockets));
         }
 
-        public static int Poller(long timeout, params Socket[] sockets) {
+        public static int Poller(long timeout, params Socket[] sockets)
+        {
             return Poller(new List<Socket>(sockets), timeout);
         }
 
@@ -219,11 +251,13 @@ namespace ZMQ {
         /// Static method
         /// </summary>
         /// <param name="skts">Socket List</param>
-        /// <param name="timeout">Timeout(micro seconds)</param>
+        /// <param name="timeout">Timeout(milliseconds)</param>
         /// <returns>Number of Poll items with events</returns>
-        public static int Poller(IList<Socket> skts, long timeout) {
+        public static int Poller(IList<Socket> skts, long timeout)
+        {
             List<PollItem> items = new List<PollItem>(skts.Count);
-            foreach (Socket skt in skts) {
+            foreach (Socket skt in skts)
+            {
                 items.Add(skt.PollItem);
             }
             return Poller(items.ToArray(), timeout);
@@ -235,7 +269,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="skts">Socket List</param>
         /// <returns>Number of Poll items with events</returns>
-        public static int Poller(IList<Socket> skts) {
+        public static int Poller(IList<Socket> skts)
+        {
             return Poller(skts, -1);
         }
     }

--- a/clrzmq/Enums.cs
+++ b/clrzmq/Enums.cs
@@ -3,6 +3,7 @@
     Copyright (c) 2010 Jeffrey Dik <s450r1@gmail.com>
     Copyright (c) 2010 Martin Sustrik <sustrik@250bpm.com>
     Copyright (c) 2010 Michael Compton <michael.compton@littleedge.co.uk>
+    Copyright (c) 2011 Calvin de Vries <devries.calvin@gmail.com>
 
     This file is part of clrzmq2.
 
@@ -23,11 +24,13 @@
 
 using System;
 
-namespace ZMQ {
+namespace ZMQ
+{
     /// <summary>
     /// Message transport types
     /// </summary>
-    public enum Transport {
+    public enum Transport
+    {
         INPROC = 1,
         TCP = 2,
         IPC = 3,
@@ -38,16 +41,14 @@ namespace ZMQ {
     /// <summary>
     /// Socket options
     /// </summary>
-    public enum SocketOpt {
-        HWM = 1,
-        SWAP = 3,
+    public enum SocketOpt
+    {
         AFFINITY = 4,
         IDENTITY = 5,
         SUBSCRIBE = 6,
         UNSUBSCRIBE = 7,
         RATE = 8,
         RECOVERY_IVL = 9,
-        MCAST_LOOP = 10,
         SNDBUF = 11,
         RCVBUF = 12,
         RCVMORE = 13,
@@ -56,13 +57,22 @@ namespace ZMQ {
         TYPE = 16,
         LINGER = 17,
         RECONNECT_IVL = 18,
-        BACKLOG = 19
+        BACKLOG = 19,
+        RECONNECT_IVL_MAX = 21,
+        MAXMSGSIZE = 22,
+        SNDHWM = 23,
+        RCVHWM = 24,
+        MULTICAST_HOPS = 25,
+        RCVTIME0 = 27,
+        SNDTIME0 = 28,
+        RCVLABEL = 29
     }
 
     /// <summary>
     /// Socket types
     /// </summary>
-    public enum SocketType {
+    public enum SocketType
+    {
         PAIR = 0,
         PUB = 1,
         SUB = 2,
@@ -70,22 +80,21 @@ namespace ZMQ {
         REP = 4,
         [Obsolete("To be removed in 3.x. Use DEALER instead.")]
         XREQ = 5,
-        DEALER = 5,
         [Obsolete("To be removed in 3.x. Use ROUTER instead.")]
         XREP = 6,
-        ROUTER = 6,
         PULL = 7,
-        [Obsolete("To be removed in 3.x. Use PULL instead.")]
-        UPSTREAM = 7,
         PUSH = 8,
-        [Obsolete("To be removed in 3.x. Use PUSH instead.")]
-        DOWNSTREAM = 8
+        XPUB = 9,
+        XSUB = 10,
+        ZMQ_ROUTER = 11,
+        ZMQ_DEALER = 12
     }
 
     /// <summary>
     /// Device types
     /// </summary>
-    public enum DeviceType {
+    public enum DeviceType
+    {
         STREAMER = 1,
         FORWARDER = 2,
         QUEUE = 3
@@ -94,33 +103,38 @@ namespace ZMQ {
     /// <summary>
     /// Send and receive options
     /// </summary>
-    public enum SendRecvOpt {
+    public enum SendRecvOpt
+    {
         NONE = 0,
-        NOBLOCK = 1,
-        SNDMORE = 2
+        DONTWAIT = 1,
+        SNDMORE = 2,
+        SNDLABEL = 4
     }
 
     /// <summary>
     /// IO Multiplexing polling events bit flags
     /// </summary>
-    public enum IOMultiPlex {
+    public enum IOMultiPlex
+    {
         POLLIN = 0x1,
         POLLOUT = 0x2,
         POLLERR = 0x4
     }
 
-    public enum ERRNOS {
-        ENOTSUP = ZHelpers.HAUSNUMERO,
-        EPROTONOSUPPORT,
-        ENOBUFS,
-        ENETDOWN,
-        EADDRINUSE,
-        EADDRNOTAVAIL,
-        ECONNREFUSED,
-        EINPROGRESS,
+    public enum ERRNOS
+    {
+        ENOTSUP = ZHelpers.HAUSNUMERO + 1,
+        EPROTONOSUPPORT = ZHelpers.HAUSNUMERO + 2,
+        ENOBUFS = ZHelpers.HAUSNUMERO + 3,
+        ENETDOWN = ZHelpers.HAUSNUMERO + 4,
+        EADDRINUSE = ZHelpers.HAUSNUMERO + 5,
+        EADDRNOTAVAIL = ZHelpers.HAUSNUMERO + 6,
+        ECONNREFUSED = ZHelpers.HAUSNUMERO + 7,
+        EINPROGRESS = ZHelpers.HAUSNUMERO + 8,
+        ENOTSOCK = ZHelpers.HAUSNUMERO + 9,
         EFSM = ZHelpers.HAUSNUMERO + 51,
-        ENOCOMPATPROTO,
-        ETERM,
-        EMTHREAD
+        ENOCOMPATPROTO = ZHelpers.HAUSNUMERO + 52,
+        ETERM = ZHelpers.HAUSNUMERO + 53,
+        EMTHREAD = ZHelpers.HAUSNUMERO + 54
     }
 }

--- a/clrzmq/Socket.cs
+++ b/clrzmq/Socket.cs
@@ -3,6 +3,7 @@
     Copyright (c) 2010 Jeffrey Dik <s450r1@gmail.com>
     Copyright (c) 2010 Martin Sustrik <sustrik@250bpm.com>
     Copyright (c) 2010 Michael Compton <michael.compton@littleedge.co.uk>
+    Copyright (c) 2011 Calvin de Vries <devries.calvin@gmail.com>
 
     This file is part of clrzmq2.
 
@@ -29,11 +30,13 @@ using SysSockets = System.Net.Sockets;
 using System.Diagnostics;
 using System.Threading;
 
-namespace ZMQ {
+namespace ZMQ
+{
     /// <summary>
     /// ZMQ Socket
     /// </summary>
-    public class Socket : IDisposable {
+    public class Socket : IDisposable
+    {
         private static Context _appContext;
         private static int _appSocketCount;
         private static Object _lockObj = new object();
@@ -58,7 +61,8 @@ namespace ZMQ {
         /// Socket method
         /// </summary>
         /// <param name="ptr">Pointer to a socket</param>
-        internal Socket(IntPtr ptr) {
+        internal Socket(IntPtr ptr)
+        {
             this._ptr = ptr;
             CommonInit(false);
         }
@@ -67,9 +71,12 @@ namespace ZMQ {
         /// Create Socket using application wide Context
         /// </summary>
         /// <param name="type">Socket type</param>
-        public Socket(SocketType type) {
-            lock (_lockObj) {
-                if (_appContext == null) {
+        public Socket(SocketType type)
+        {
+            lock (_lockObj)
+            {
+                if (_appContext == null)
+                {
                     _appContext = new Context();
                 }
                 _ptr = _appContext.CreateSocketPtr(type);
@@ -78,33 +85,40 @@ namespace ZMQ {
             CommonInit(true);
         }
 
-        private void CommonInit(bool local) {
+        private void CommonInit(bool local)
+        {
             _msg = Marshal.AllocHGlobal(ZMQ_MSG_T_SIZE);
             _localSocket = local;
             _pollItem = new PollItem(new ZMQPollItem(_ptr, 0, 0), this);
         }
 
-        ~Socket() {
+        ~Socket()
+        {
             Dispose(false);
         }
 
-        public void Dispose() {
+        public void Dispose()
+        {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        internal IntPtr Ptr {
-            get { return _ptr;}
+        internal IntPtr Ptr
+        {
+            get { return _ptr; }
         }
 
         /// <summary>
         /// POLLIN event handler
         /// </summary>
-        public event PollHandler PollInHandler {
-            add {
-                _pollItem.PollInHandler += value;                
+        public event PollHandler PollInHandler
+        {
+            add
+            {
+                _pollItem.PollInHandler += value;
             }
-            remove {
+            remove
+            {
                 _pollItem.PollInHandler -= value;
             }
         }
@@ -112,11 +126,14 @@ namespace ZMQ {
         /// <summary>
         /// POLLOUT event handler
         /// </summary>
-        public event PollHandler PollOutHandler {
-            add {
-                _pollItem.PollOutHandler += value;                
+        public event PollHandler PollOutHandler
+        {
+            add
+            {
+                _pollItem.PollOutHandler += value;
             }
-            remove {
+            remove
+            {
                 _pollItem.PollOutHandler -= value;
             }
         }
@@ -124,35 +141,45 @@ namespace ZMQ {
         /// <summary>
         /// POLLERR event handler
         /// </summary>
-        public event PollHandler PollErrHandler {
-            add {
+        public event PollHandler PollErrHandler
+        {
+            add
+            {
                 _pollItem.PollErrHandler += value;
             }
-            remove {
+            remove
+            {
                 _pollItem.PollErrHandler -= value;
             }
         }
 
-        internal PollItem PollItem {
+        internal PollItem PollItem
+        {
             get { return _pollItem; }
         }
 
-        protected virtual void Dispose(bool disposing) {
-            if (_msg != IntPtr.Zero) {
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_msg != IntPtr.Zero)
+            {
                 Marshal.FreeHGlobal(_msg);
                 _msg = IntPtr.Zero;
             }
 
-            if (_ptr != IntPtr.Zero) {
+            if (_ptr != IntPtr.Zero)
+            {
                 int rc = C.zmq_close(_ptr);
                 _ptr = IntPtr.Zero;
                 if (rc != 0)
                     throw new Exception();
             }
-            if (_localSocket) {
+            if (_localSocket)
+            {
                 Interlocked.Decrement(ref _appSocketCount);
-                lock (_lockObj) {
-                    if (_appSocketCount == 0) {
+                lock (_lockObj)
+                {
+                    if (_appSocketCount == 0)
+                    {
                         _appContext.Dispose();
                         _appContext = null;
                     }
@@ -166,7 +193,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="ptr">Pointer to a size_t</param>
         /// <returns>Size_t value</returns>
-        private object ReadSizeT(IntPtr ptr) {
+        private object ReadSizeT(IntPtr ptr)
+        {
             return unchecked((uint)Marshal.ReadInt32(ptr));
         }
 
@@ -175,7 +203,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="ptr">Pointer to a size_</param>
         /// <param name="val">Value to write</param>
-        private void WriteSizeT(IntPtr ptr, object val) {
+        private void WriteSizeT(IntPtr ptr, object val)
+        {
             Marshal.WriteInt32(ptr, unchecked(Convert.ToInt32(val)));
         }
 #elif x64
@@ -202,7 +231,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="events">Listening events</param>
         /// <returns>Socket Poll item</returns>
-        public PollItem CreatePollItem(IOMultiPlex events) {
+        public PollItem CreatePollItem(IOMultiPlex events)
+        {
             return new PollItem(new ZMQPollItem(_ptr, 0, (short)events), this);
         }
 
@@ -213,7 +243,8 @@ namespace ZMQ {
         /// <param name="sysSocket">Raw Socket</param>
         /// <returns>Socket Poll item</returns>
         public PollItem CreatePollItem(IOMultiPlex events,
-                                       SysSockets.Socket sysSocket) {
+                                       SysSockets.Socket sysSocket)
+        {
 #if x86 || POSIX
             return new PollItem(new ZMQPollItem(_ptr, sysSocket.Handle.ToInt32(),
                                                 (short)events), this);
@@ -230,10 +261,12 @@ namespace ZMQ {
         /// <param name="option">Socket Option</param>
         /// <param name="value">Option value</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void SetSockOpt(SocketOpt option, ulong value) {
+        public void SetSockOpt(SocketOpt option, ulong value)
+        {
             int sizeOfValue = Marshal.SizeOf(typeof(ulong));
-            using (DisposableIntPtr valPtr = new DisposableIntPtr(sizeOfValue)) {
-                Marshal.WriteInt64(valPtr.Ptr, unchecked(Convert.ToInt64(value)));
+            using (DisposableIntPtr valPtr = new DisposableIntPtr(sizeOfValue))
+            {
+                Marshal.WriteInt32(valPtr.Ptr, unchecked(Convert.ToInt32(value)));
                 if (C.zmq_setsockopt(_ptr, (int)option, valPtr.Ptr, sizeOfValue) != 0)
                     throw new Exception();
             }
@@ -245,8 +278,10 @@ namespace ZMQ {
         /// <param name="option">Socket Option</param>
         /// <param name="value">Option value</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void SetSockOpt(SocketOpt option, byte[] value) {
-            using (DisposableIntPtr valPtr = new DisposableIntPtr(value.Length)) {
+        public void SetSockOpt(SocketOpt option, byte[] value)
+        {
+            using (DisposableIntPtr valPtr = new DisposableIntPtr(value.Length))
+            {
                 Marshal.Copy(value, 0, valPtr.Ptr, value.Length);
                 if (C.zmq_setsockopt(_ptr, (int)option, valPtr.Ptr, value.Length) != 0)
                     throw new Exception();
@@ -259,9 +294,11 @@ namespace ZMQ {
         /// <param name="option">Socket Option</param>
         /// <param name="value">Option value</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void SetSockOpt(SocketOpt option, int value) {
+        public void SetSockOpt(SocketOpt option, int value)
+        {
             int sizeOfValue = Marshal.SizeOf(typeof(int));
-            using (DisposableIntPtr valPtr = new DisposableIntPtr(sizeOfValue)) {
+            using (DisposableIntPtr valPtr = new DisposableIntPtr(sizeOfValue))
+            {
                 Marshal.WriteInt32(valPtr.Ptr, Convert.ToInt32(value));
                 if (C.zmq_setsockopt(_ptr, (int)option, valPtr.Ptr, sizeOfValue) != 0)
                     throw new Exception();
@@ -274,10 +311,12 @@ namespace ZMQ {
         /// <param name="option">Socket Option</param>
         /// <param name="value">Option value</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void SetSockOpt(SocketOpt option, long value) {
+        public void SetSockOpt(SocketOpt option, long value)
+        {
             int sizeOfValue = Marshal.SizeOf(typeof(long));
-            using (DisposableIntPtr valPtr = new DisposableIntPtr(sizeOfValue)) {
-                Marshal.WriteInt64(valPtr.Ptr, Convert.ToInt64(value));
+            using (DisposableIntPtr valPtr = new DisposableIntPtr(sizeOfValue))
+            {
+                Marshal.WriteInt32(valPtr.Ptr, Convert.ToInt32(value));
                 if (C.zmq_setsockopt(_ptr, (int)option, valPtr.Ptr, sizeOfValue) != 0)
                     throw new Exception();
             }
@@ -289,13 +328,17 @@ namespace ZMQ {
         /// <param name="option">Socket Option</param>
         /// <returns>Option value</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public object GetSockOpt(SocketOpt option) {
+        public object GetSockOpt(SocketOpt option)
+        {
             const int IDLenSize = 255;  //Identity value length 255 bytes
             const int lenSize = 8;      //Non-Identity value size 8 bytes
             object output;
-            using (DisposableIntPtr len = new DisposableIntPtr(IntPtr.Size)) {
-                if (option == SocketOpt.IDENTITY) {
-                    using (DisposableIntPtr val = new DisposableIntPtr(IDLenSize)) {
+            using (DisposableIntPtr len = new DisposableIntPtr(IntPtr.Size))
+            {
+                if (option == SocketOpt.IDENTITY)
+                {
+                    using (DisposableIntPtr val = new DisposableIntPtr(IDLenSize))
+                    {
                         WriteSizeT(len.Ptr, IDLenSize);
                         if (C.zmq_getsockopt(_ptr, (int)option, val.Ptr, len.Ptr) != 0)
                             throw new Exception();
@@ -303,23 +346,28 @@ namespace ZMQ {
                         Marshal.Copy(val.Ptr, buffer, 0, buffer.Length);
                         output = buffer;
                     }
-                } else {
-                    using (DisposableIntPtr val = new DisposableIntPtr(lenSize)) {
+                }
+                else
+                {
+                    using (DisposableIntPtr val = new DisposableIntPtr(lenSize))
+                    {
                         WriteSizeT(len.Ptr, lenSize);
                         if (C.zmq_getsockopt(_ptr, (int)option, val.Ptr, len.Ptr) != 0)
                             throw new Exception();
 
-                        switch (option) {
-                            case SocketOpt.HWM:
+                        switch (option)
+                        {
+                            case SocketOpt.SNDHWM:
+                            case SocketOpt.RCVHWM:
                             case SocketOpt.AFFINITY:
                             case SocketOpt.SNDBUF:
                             case SocketOpt.RCVBUF:
                                 //Unchecked casting of uint64 options
-                                output = unchecked((ulong)Marshal.ReadInt64(val.Ptr));
+                                output = unchecked((ulong)Marshal.ReadInt32(val.Ptr));
                                 break;
                             case SocketOpt.LINGER:
                             case SocketOpt.BACKLOG:
-                            case SocketOpt.RECONNECT_IVL:                            
+                            case SocketOpt.RECONNECT_IVL:
                                 output = Marshal.ReadInt32(val.Ptr);
                                 break;
                             case SocketOpt.EVENTS:
@@ -347,7 +395,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="addr">Socket Address</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Bind(string addr) {
+        public void Bind(string addr)
+        {
             _address = addr;
             if (C.zmq_bind(_ptr, addr) != 0)
                 throw new Exception();
@@ -360,7 +409,8 @@ namespace ZMQ {
         /// <param name="addr">Socket address</param>
         /// <param name="port">Socket port</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Bind(Transport transport, string addr, uint port) {
+        public void Bind(Transport transport, string addr, uint port)
+        {
             Bind(Enum.GetName(typeof(Transport), transport).ToLower() + "://" +
                  addr + ":" + port);
         }
@@ -371,7 +421,8 @@ namespace ZMQ {
         /// <param name="transport">Socket transport type</param>
         /// <param name="addr">Socket address</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Bind(Transport transport, string addr) {
+        public void Bind(Transport transport, string addr)
+        {
             Bind(Enum.GetName(typeof(Transport), transport).ToLower() + "://" +
                  addr);
         }
@@ -381,7 +432,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="addr">Destination Address</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Connect(string addr) {
+        public void Connect(string addr)
+        {
             _address = addr;
             if (C.zmq_connect(_ptr, addr) != 0)
                 throw new Exception();
@@ -394,7 +446,8 @@ namespace ZMQ {
         /// <param name="addr">Socket address</param>
         /// <param name="port">Socket port</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Connect(Transport transport, string addr, uint port) {
+        public void Connect(Transport transport, string addr, uint port)
+        {
             Connect(Enum.GetName(typeof(Transport), transport).ToLower() +
                     "://" + addr + ":" + port);
         }
@@ -405,7 +458,8 @@ namespace ZMQ {
         /// <param name="transport">Socket transport type</param>
         /// <param name="addr">Socket address</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Connect(Transport transport, string addr) {
+        public void Connect(Transport transport, string addr)
+        {
             Connect(Enum.GetName(typeof(Transport), transport).ToLower() +
                     "://" + addr);
         }
@@ -414,17 +468,22 @@ namespace ZMQ {
         /// Forward all message parts directly to destination. No marshalling performed.
         /// </summary>
         /// <param name="destination">Destination Socket</param>
-        public void Forward(Socket destination) {
+        public void Forward(Socket destination)
+        {
             SendRecvOpt opt = SendRecvOpt.SNDMORE;
-            while (opt == SendRecvOpt.SNDMORE) {
+            while (opt == SendRecvOpt.SNDMORE)
+            {
                 if (C.zmq_msg_init(_msg) != 0)
                     throw new Exception();
-                if (C.zmq_recv(_ptr, _msg, 0) == 0) {
+                if (C.zmq_recvmsg(_ptr, _msg, 0) == 0)
+                {
                     opt = RcvMore ? SendRecvOpt.SNDMORE : SendRecvOpt.NONE;
-                    if (C.zmq_send(destination.Ptr, _msg, (int)opt) != 0)
+                    if (C.zmq_sendmsg(destination.Ptr, _msg, (int)opt) != 0)
                         throw new Exception();
                     C.zmq_msg_close(_msg);
-                } else {
+                }
+                else
+                {
                     if (C.zmq_errno() != EAGAIN)
                         throw new Exception();
                 }
@@ -437,26 +496,38 @@ namespace ZMQ {
         /// <param name="flags">Receive Options</param>
         /// <returns>Message</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public byte[] Recv(params SendRecvOpt[] flags) {
+        public byte[] Recv(params SendRecvOpt[] flags)
+        {
             byte[] message = null;
             int flagsVal = 0;
-            foreach (SendRecvOpt opt in flags) {
+            foreach (SendRecvOpt opt in flags)
+            {
                 flagsVal += (int)opt;
             }
             if (C.zmq_msg_init(_msg) != 0)
                 throw new Exception();
-            while(true){
-                if (C.zmq_recv(_ptr, _msg, flagsVal) == 0) {
+            while (true)
+            {
+                if (C.zmq_recvmsg(_ptr, _msg, flagsVal) >= 0)
+                {
                     message = new byte[C.zmq_msg_size(_msg)];
                     Marshal.Copy(C.zmq_msg_data(_msg), message, 0, message.Length);
                     C.zmq_msg_close(_msg);
                     break;
-                } else {
-                    if (C.zmq_errno() == 4) {
+                }
+                else
+                {
+                    if (C.zmq_errno() == 4)
+                    {
                         continue;
-                    } else if (C.zmq_errno() != EAGAIN) {
+                    }
+                    else if (C.zmq_errno() != EAGAIN)
+                    {
                         throw new Exception();
-                    } else {
+                    }
+                    else
+                    {
+                        Console.WriteLine("ZMQ Error #: " + C.zmq_errno());
                         break;
                     }
                 }
@@ -464,12 +535,14 @@ namespace ZMQ {
             return message;
         }
 
+
         /// <summary>
         /// Listen for message
         /// </summary>
         /// <returns>Message</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public byte[] Recv() {
+        public byte[] Recv()
+        {
             return Recv(SendRecvOpt.NONE);
         }
 
@@ -479,12 +552,14 @@ namespace ZMQ {
         /// <param name="timeout">Timeout in milliseconds</param>
         /// <returns>Message</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public byte[] Recv(int timeout) {
+        public byte[] Recv(int timeout)
+        {
             Stopwatch timer = new Stopwatch();
             byte[] data = null;
             timer.Start();
-            while (data == null && timer.ElapsedMilliseconds <= timeout) {
-                data = Recv(SendRecvOpt.NOBLOCK);
+            while (data == null && timer.ElapsedMilliseconds <= timeout)
+            {
+                data = Recv(SendRecvOpt.DONTWAIT);
             }
             return data;
         }
@@ -495,7 +570,8 @@ namespace ZMQ {
         /// <param name="encoding">String encoding</param>
         /// <returns>Message string</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public string Recv(Encoding encoding) {
+        public string Recv(Encoding encoding)
+        {
             return Recv(encoding, SendRecvOpt.NONE);
         }
 
@@ -506,11 +582,15 @@ namespace ZMQ {
         /// <param name="timeout">Timeout in milliseconds</param>
         /// <returns>Message string</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public string Recv(Encoding encoding, int timeout) {
+        public string Recv(Encoding encoding, int timeout)
+        {
             byte[] data = Recv(timeout);
-            if(data == null) {
+            if (data == null)
+            {
                 return null;
-            } else {
+            }
+            else
+            {
                 return encoding.GetString(data);
             }
         }
@@ -522,11 +602,15 @@ namespace ZMQ {
         /// <param name="flags">Receive options</param>
         /// <returns>Message string</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public string Recv(Encoding encoding, params SendRecvOpt[] flags) {
+        public string Recv(Encoding encoding, params SendRecvOpt[] flags)
+        {
             byte[] data = Recv(flags);
-            if(data == null) {
+            if (data == null)
+            {
                 return null;
-            } else {
+            }
+            else
+            {
                 return encoding.GetString(data);
             }
         }
@@ -536,8 +620,9 @@ namespace ZMQ {
         /// </summary>
         /// <returns>Queue of message parts</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public Queue<byte[]> RecvAll() {
-            return RecvAll(SendRecvOpt.NONE);
+        public Queue<byte[]> RecvAll()
+        {
+            return RecvAll(0);
         }
 
         /// <summary>
@@ -546,10 +631,12 @@ namespace ZMQ {
         /// <param name="flags">Receive options</param>
         /// <returns>Queue of message parts</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public Queue<byte[]> RecvAll(params SendRecvOpt[] flags) {
+        public Queue<byte[]> RecvAll(params SendRecvOpt[] flags)
+        {
             Queue<byte[]> messages = new Queue<byte[]>();
             messages.Enqueue(Recv(flags));
-            while (RcvMore) {
+            while (RcvMore)
+            {
                 messages.Enqueue(Recv(flags));
             }
             return messages;
@@ -561,10 +648,12 @@ namespace ZMQ {
         /// <param name="encoding">String Encoding</param>
         /// <returns>Queue of message parts as strings</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public Queue<string> RecvAll(Encoding encoding) {
+        public Queue<string> RecvAll(Encoding encoding)
+        {
             Queue<string> messages = new Queue<string>();
             messages.Enqueue(Recv(encoding));
-            while (RcvMore) {
+            while (RcvMore)
+            {
                 messages.Enqueue(Recv(encoding));
             }
             return messages;
@@ -579,10 +668,12 @@ namespace ZMQ {
         /// <returns>Queue of message parts</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
         public Queue<string> RecvAll(Encoding encoding,
-                                     params SendRecvOpt[] flags) {
+                                     params SendRecvOpt[] flags)
+        {
             Queue<string> messages = new Queue<string>();
             messages.Enqueue(Recv(encoding, flags));
-            while (RcvMore) {
+            while (RcvMore)
+            {
                 messages.Enqueue(Recv(encoding, flags));
             }
             return messages;
@@ -594,15 +685,17 @@ namespace ZMQ {
         /// <param name="message">Message</param>
         /// <param name="flags">Send Options</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Send(byte[] message, params SendRecvOpt[] flags) {
+        public void Send(byte[] message, params SendRecvOpt[] flags)
+        {
             int flagsVal = 0;
-            foreach (SendRecvOpt opt in flags) {
+            foreach (SendRecvOpt opt in flags)
+            {
                 flagsVal += (int)opt;
             }
             if (C.zmq_msg_init_size(_msg, message.Length) != 0)
                 throw new Exception();
             Marshal.Copy(message, 0, C.zmq_msg_data(_msg), message.Length);
-            if (C.zmq_send(_ptr, _msg, flagsVal) != 0)
+            if (C.zmq_sendmsg(_ptr, _msg, flagsVal) != 0)
                 throw new Exception();
         }
 
@@ -611,7 +704,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="message">Message</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Send(byte[] message) {
+        public void Send(byte[] message)
+        {
             Send(message, SendRecvOpt.NONE);
         }
 
@@ -621,21 +715,24 @@ namespace ZMQ {
         /// <param name="message">Message string</param>
         /// <param name="encoding">String encoding</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Send(string message, Encoding encoding) {
+        public void Send(string message, Encoding encoding)
+        {
             Send(message, encoding, SendRecvOpt.NONE);
         }
 
         /// <summary>
         /// Send empty message part
         /// </summary>
-        public void Send() {
+        public void Send()
+        {
             Send(new byte[0]);
         }
 
         /// <summary>
         /// Send empty message part
         /// </summary>
-        public void SendMore() {
+        public void SendMore()
+        {
             Send(new byte[0], SendRecvOpt.SNDMORE);
         }
 
@@ -644,7 +741,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="message">Message</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void SendMore(byte[] message) {
+        public void SendMore(byte[] message)
+        {
             Send(message, SendRecvOpt.SNDMORE);
         }
 
@@ -654,7 +752,8 @@ namespace ZMQ {
         /// <param name="message">Message</param>
         /// <param name="encoding">String encoding</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void SendMore(string message, Encoding encoding) {
+        public void SendMore(string message, Encoding encoding)
+        {
             Send(message, encoding, SendRecvOpt.SNDMORE);
         }
 
@@ -666,7 +765,8 @@ namespace ZMQ {
         /// <param name="flags">Send options</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
         public void SendMore(string message, Encoding encoding,
-                             params SendRecvOpt[] flags) {
+                             params SendRecvOpt[] flags)
+        {
             Send(message, encoding, flags);
         }
 
@@ -677,7 +777,8 @@ namespace ZMQ {
         /// <param name="flags">Send Options</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
         public void Send(string message, Encoding encoding,
-                         params SendRecvOpt[] flags) {
+                         params SendRecvOpt[] flags)
+        {
             Send(encoding.GetBytes(message), flags);
         }
 
@@ -687,7 +788,8 @@ namespace ZMQ {
         /// <param name="encoding">String encoding</param>
         /// <returns>Socket Identity</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public string IdentityToString(Encoding encoding) {
+        public string IdentityToString(Encoding encoding)
+        {
             return encoding.GetString(Identity);
         }
 
@@ -697,7 +799,8 @@ namespace ZMQ {
         /// <param name="identity">Identity</param>
         /// <param name="encoding">String encoding</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void StringToIdentity(string identity, Encoding encoding) {
+        public void StringToIdentity(string identity, Encoding encoding)
+        {
             Identity = encoding.GetBytes(identity);
         }
 
@@ -705,25 +808,47 @@ namespace ZMQ {
         /// Gets or Sets socket identity
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public byte[] Identity {
-            get {
+        public byte[] Identity
+        {
+            get
+            {
                 return (byte[])GetSockOpt(SocketOpt.IDENTITY);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.IDENTITY, value);
             }
         }
 
         /// <summary>
-        /// Gets or Sets socket High Water Mark
+        /// Gets or Sets socket Sender High Water Mark
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public ulong HWM {
-            get {
-                return (ulong)GetSockOpt(SocketOpt.HWM);
+        public ulong SNDHWM
+        {
+            get
+            {
+                return (ulong)GetSockOpt(SocketOpt.SNDHWM);
             }
-            set {
-                SetSockOpt(SocketOpt.HWM, value);
+            set
+            {
+                SetSockOpt(SocketOpt.SNDHWM, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or Sets socket Sender High Water Mark
+        /// </summary>
+        /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
+        public ulong RCVHWM
+        {
+            get
+            {
+                return (ulong)GetSockOpt(SocketOpt.RCVHWM);
+            }
+            set
+            {
+                SetSockOpt(SocketOpt.RCVHWM, value);
             }
         }
 
@@ -731,22 +856,11 @@ namespace ZMQ {
         /// Gets socket more messages indicator (multipart message)
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public bool RcvMore {
-            get {
+        public bool RcvMore
+        {
+            get
+            {
                 return (long)GetSockOpt(SocketOpt.RCVMORE) == 1;
-            }
-        }
-
-        /// <summary>
-        /// Gets or Sets socket swap
-        /// </summary>
-        /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public long Swap {
-            get {
-                return (long)GetSockOpt(SocketOpt.SWAP);
-            }
-            set {
-                SetSockOpt(SocketOpt.SWAP, value);
             }
         }
 
@@ -754,11 +868,14 @@ namespace ZMQ {
         /// Gets or Sets socket thread affinity
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public ulong Affinity {
-            get {
+        public ulong Affinity
+        {
+            get
+            {
                 return (ulong)GetSockOpt(SocketOpt.AFFINITY);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.AFFINITY, value);
             }
         }
@@ -767,11 +884,14 @@ namespace ZMQ {
         /// Gets or Sets socket transfer rate
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public long Rate {
-            get {
+        public long Rate
+        {
+            get
+            {
                 return (long)GetSockOpt(SocketOpt.RATE);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.RATE, value);
             }
         }
@@ -780,25 +900,15 @@ namespace ZMQ {
         /// Gets or Sets socket recovery interval
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public long RecoveryIvl {
-            get {
+        public long RecoveryIvl
+        {
+            get
+            {
                 return (long)GetSockOpt(SocketOpt.RECOVERY_IVL);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.RECOVERY_IVL, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or Sets socket MultiCast Loop
-        /// </summary>
-        /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public long MCastLoop {
-            get {
-                return (long)GetSockOpt(SocketOpt.MCAST_LOOP);
-            }
-            set {
-                SetSockOpt(SocketOpt.MCAST_LOOP, value);
             }
         }
 
@@ -806,11 +916,14 @@ namespace ZMQ {
         /// Gets or Sets socket Send buffer size(bytes)
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public ulong SndBuf {
-            get {
+        public ulong SndBuf
+        {
+            get
+            {
                 return (ulong)GetSockOpt(SocketOpt.SNDBUF);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.SNDBUF, value);
             }
         }
@@ -819,11 +932,14 @@ namespace ZMQ {
         /// Gets or Sets socket Receive buffer size(bytes)
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public ulong RcvBuf {
-            get {
+        public ulong RcvBuf
+        {
+            get
+            {
                 return (ulong)GetSockOpt(SocketOpt.RCVBUF);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.RCVBUF, value);
             }
         }
@@ -832,11 +948,14 @@ namespace ZMQ {
         /// Get or Set linger period for socket shutdown
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public int Linger {
-            get {
+        public int Linger
+        {
+            get
+            {
                 return (int)GetSockOpt(SocketOpt.LINGER);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.LINGER, value);
             }
         }
@@ -845,11 +964,14 @@ namespace ZMQ {
         /// Get or Set reconnection interval
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public int ReconnectIvl {
-            get {
+        public int ReconnectIvl
+        {
+            get
+            {
                 return (int)GetSockOpt(SocketOpt.RECONNECT_IVL);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.RECONNECT_IVL, value);
             }
         }
@@ -858,11 +980,14 @@ namespace ZMQ {
         /// Get or Set maximum length of the queue of outstanding connections
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public int Backlog {
-            get {
+        public int Backlog
+        {
+            get
+            {
                 return (int)GetSockOpt(SocketOpt.BACKLOG);
             }
-            set {
+            set
+            {
                 SetSockOpt(SocketOpt.BACKLOG, value);
             }
         }
@@ -882,8 +1007,10 @@ namespace ZMQ {
         /// Get Socket winsock HANDLE
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public IntPtr FD {
-            get {
+        public IntPtr FD
+        {
+            get
+            {
                 return (IntPtr)GetSockOpt(SocketOpt.FD);
             }
         }
@@ -894,14 +1021,18 @@ namespace ZMQ {
         /// Get socket event state
         /// </summary>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public IOMultiPlex[] Events {
-            get {
+        public IOMultiPlex[] Events
+        {
+            get
+            {
                 uint evts = (uint)GetSockOpt(SocketOpt.EVENTS);
                 List<IOMultiPlex> evtList = new List<IOMultiPlex>();
-                if (((int)IOMultiPlex.POLLIN & evts) > 0) {
+                if (((int)IOMultiPlex.POLLIN & evts) > 0)
+                {
                     evtList.Add(IOMultiPlex.POLLIN);
                 }
-                if (((int)IOMultiPlex.POLLOUT & evts) > 0) {
+                if (((int)IOMultiPlex.POLLOUT & evts) > 0)
+                {
                     evtList.Add(IOMultiPlex.POLLOUT);
                 }
                 return evtList.ToArray();
@@ -911,8 +1042,10 @@ namespace ZMQ {
         /// <summary>
         /// Get connection address
         /// </summary>
-        public string Address {
-            get {
+        public string Address
+        {
+            get
+            {
                 return _address;
             }
         }
@@ -922,7 +1055,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="filter">Filter</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Subscribe(byte[] filter) {
+        public void Subscribe(byte[] filter)
+        {
             SetSockOpt(SocketOpt.SUBSCRIBE, filter);
         }
 
@@ -931,7 +1065,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="filter">Filter</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Subscribe(string filter, Encoding encoding) {
+        public void Subscribe(string filter, Encoding encoding)
+        {
             SetSockOpt(SocketOpt.SUBSCRIBE, encoding.GetBytes(filter));
         }
 
@@ -940,7 +1075,8 @@ namespace ZMQ {
         /// </summary>
         /// <param name="filter">Filter</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Unsubscribe(byte[] filter) {
+        public void Unsubscribe(byte[] filter)
+        {
             SetSockOpt(SocketOpt.UNSUBSCRIBE, filter);
         }
 
@@ -949,18 +1085,21 @@ namespace ZMQ {
         /// </summary>
         /// <param name="filter">Filter</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Unsubscribe(string filter, Encoding encoding) {
+        public void Unsubscribe(string filter, Encoding encoding)
+        {
             SetSockOpt(SocketOpt.UNSUBSCRIBE, encoding.GetBytes(filter));
         }
 
-        public bool CheckEvent (IOMultiPlex revent) {
+        public bool CheckEvent(IOMultiPlex revent)
+        {
             return _pollItem.CheckEvent(revent);
         }
 
         /// <summary>
         /// ZMQ Device creation
         /// </summary>
-        public static class Device {
+        public static class Device
+        {
             /// <summary>
             /// Create ZMQ Device
             /// </summary>
@@ -969,7 +1108,8 @@ namespace ZMQ {
             /// <param name="outSocket">Output socket</param>
             /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
             public static void Create(DeviceType device, Socket inSocket,
-                                      Socket outSocket) {
+                                      Socket outSocket)
+            {
                 if (C.zmq_device((int)device, inSocket._ptr, outSocket._ptr) != 0)
                     throw new Exception();
             }
@@ -980,7 +1120,8 @@ namespace ZMQ {
             /// <param name="inSocket">Input socket</param>
             /// <param name="outSocket">Output socket</param>
             /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-            public static void Queue(Socket inSocket, Socket outSocket) {
+            public static void Queue(Socket inSocket, Socket outSocket)
+            {
                 Create(DeviceType.QUEUE, inSocket, outSocket);
             }
 
@@ -990,7 +1131,8 @@ namespace ZMQ {
             /// <param name="inSocket">Input socket</param>
             /// <param name="outSocket">Output socket</param>
             /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-            public static void Forwarder(Socket inSocket, Socket outSocket) {
+            public static void Forwarder(Socket inSocket, Socket outSocket)
+            {
                 Create(DeviceType.FORWARDER, inSocket, outSocket);
             }
 
@@ -1000,7 +1142,8 @@ namespace ZMQ {
             /// <param name="inSocket">Input socket</param>
             /// <param name="outSocket">Output socket</param>
             /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-            public static void Streamer(Socket inSocket, Socket outSocket) {
+            public static void Streamer(Socket inSocket, Socket outSocket)
+            {
                 Create(DeviceType.STREAMER, inSocket, outSocket);
             }
         }

--- a/clrzmq/Socket.cs
+++ b/clrzmq/Socket.cs
@@ -695,7 +695,7 @@ namespace ZMQ
             if (C.zmq_msg_init_size(_msg, message.Length) != 0)
                 throw new Exception();
             Marshal.Copy(message, 0, C.zmq_msg_data(_msg), message.Length);
-            if (C.zmq_sendmsg(_ptr, _msg, flagsVal) != 0)
+            if (C.zmq_sendmsg(_ptr, _msg, flagsVal) < 0)
                 throw new Exception();
         }
 

--- a/clrzmq/Socket.cs
+++ b/clrzmq/Socket.cs
@@ -316,7 +316,7 @@ namespace ZMQ
             int sizeOfValue = Marshal.SizeOf(typeof(long));
             using (DisposableIntPtr valPtr = new DisposableIntPtr(sizeOfValue))
             {
-                Marshal.WriteInt32(valPtr.Ptr, Convert.ToInt32(value));
+                Marshal.WriteInt64(valPtr.Ptr, Convert.ToInt64(value));
                 if (C.zmq_setsockopt(_ptr, (int)option, valPtr.Ptr, sizeOfValue) != 0)
                     throw new Exception();
             }

--- a/clrzmq/zmq_ffi.cs
+++ b/clrzmq/zmq_ffi.cs
@@ -56,16 +56,16 @@ namespace ZMQ
         CallingConvention = CallingConvention.Cdecl)]
         public static extern int zmq_connect(IntPtr socket, string addr);
 
-        // This is included for POSIX compliance, Windows is not a POSIX platform, leaving it out
-        //[DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
-        //public static extern int zmq_recv(IntPtr socket, IntPtr buffer, int bufflen, int flags);
+        // This is included for POSIX compliance
+        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int zmq_recv(IntPtr socket, IntPtr buffer, int bufflen, int flags);
 
         [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
         public static extern int zmq_recvmsg(IntPtr socket, IntPtr msg, int flags);
 
-        // This is included for POSIX compliance, Windows is not a POSIX platform, leaving it out
-        //[DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
-        //public static extern int zmq_send(IntPtr socket, IntPtr buffer, int bufflen, int flags);
+        // This is included for POSIX compliance
+        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int zmq_send(IntPtr socket, IntPtr buffer, int bufflen, int flags);
 
         [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
         public static extern int zmq_sendmsg(IntPtr socket, IntPtr msg, int flags);

--- a/clrzmq/zmq_ffi.cs
+++ b/clrzmq/zmq_ffi.cs
@@ -3,6 +3,7 @@
     Copyright (c) 2010 Jeffrey Dik <s450r1@gmail.com>
     Copyright (c) 2010 Martin Sustrik <sustrik@250bpm.com>
     Copyright (c) 2010 Michael Compton <michael.compton@littleedge.co.uk>
+    Copyright (c) 2011 Calvin de Vries <devries.calvin@gmail.com>
      
     This file is part of clrzmq.
      
@@ -25,8 +26,10 @@ using System;
 using System.Text;
 using System.Runtime.InteropServices;
 
-namespace ZMQ {
-    internal static class C {
+namespace ZMQ
+{
+    internal static class C
+    {
         [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr zmq_init(int io_threads);
 
@@ -53,11 +56,19 @@ namespace ZMQ {
         CallingConvention = CallingConvention.Cdecl)]
         public static extern int zmq_connect(IntPtr socket, string addr);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int zmq_recv(IntPtr socket, IntPtr msg, int flags);
+        // This is included for POSIX compliance, Windows is not a POSIX platform, leaving it out
+        //[DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        //public static extern int zmq_recv(IntPtr socket, IntPtr buffer, int bufflen, int flags);
 
         [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int zmq_send(IntPtr socket, IntPtr msg, int flags);
+        public static extern int zmq_recvmsg(IntPtr socket, IntPtr msg, int flags);
+
+        // This is included for POSIX compliance, Windows is not a POSIX platform, leaving it out
+        //[DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        //public static extern int zmq_send(IntPtr socket, IntPtr buffer, int bufflen, int flags);
+
+        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int zmq_sendmsg(IntPtr socket, IntPtr msg, int flags);
 
         [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr zmq_socket(IntPtr context, int type);


### PR DESCRIPTION
This modifies several files in clrzmq2 to support underlying zmq3.0 as opposed to 2.x

It is not backwards compatible - it uses zmq_recvmsg and zmq_sendmsg instead of zmq_send and zmq_recv. While zmq_send and zmq_recv still exist in zmq3.0 as POSIX compatible functions and are implemented in this library, they take different parameters. Perhaps this can be a branch called clrzmq3?
