### PR TITLE
New overload for Socket.Recv

### DIFF
--- a/src/clrzmq/Socket.cs
+++ b/src/clrzmq/Socket.cs
@@ -463,8 +463,7 @@ namespace ZMQ {
         /// <param name="flags">Receive Options</param>
         /// <returns>Message</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public byte[] Recv(byte[] message, out int size, params SendRecvOpt[] flags)
-        {
+        public byte[] Recv(byte[] message, out int size, params SendRecvOpt[] flags) {
             size = -1;
             int flagsVal = 0;
             foreach (SendRecvOpt opt in flags) {
@@ -485,12 +484,10 @@ namespace ZMQ {
                     C.zmq_msg_close(_msg);
                     break;
                 }
-                if (C.zmq_errno() == 4)
-                {
+                if (C.zmq_errno() == 4) {
                     continue;
                 }
-                if (C.zmq_errno() != (int)ERRNOS.EAGAIN)
-                {
+                if (C.zmq_errno() != (int)ERRNOS.EAGAIN) {
                     throw new Exception();
                 }
                 break;

--- a/src/clrzmq/Socket.cs
+++ b/src/clrzmq/Socket.cs
@@ -675,26 +675,71 @@ namespace ZMQ {
             return messages;
         }
 
+        
+        /// <summary>
+        /// Send Message
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <param name="length">Length of data to send from message</param>
+        /// <param name="flags">Send Options</param>
+        public void Send(byte[] message, int length, params SendRecvOpt[] flags)
+        {
+            Send(message, 0, length, flags);
+        }
+
+        /// <summary>
+        /// Send Message
+        /// </summary>
+        /// <param name="message">Message</param>
+        /// <param name="startIndex">Index to start reading data from</param>
+        /// <param name="length">Length of data to send from message, starting at startIndex</param>
+        /// <param name="flags">Send Options</param>
+        public void Send(byte[] message, int startIndex, int length, params SendRecvOpt[] flags)
+        {
+            if (message == null)
+            {
+                throw new ArgumentNullException("message");
+            }
+
+            if (message.Length < (startIndex + length))
+            {
+                throw new InvalidOperationException("message was smaller then startindex + length");
+            }
+
+            int flagsVal = 0;
+
+            foreach (SendRecvOpt opt in flags)
+            {
+                flagsVal += (int)opt;
+            }
+
+            if (C.zmq_msg_init_size(_msg, length) != 0)
+            {
+                throw new Exception();
+            }
+
+            Marshal.Copy(message, startIndex, C.zmq_msg_data(_msg), length);
+
+            if (C.zmq_send(Ptr, _msg, flagsVal) != 0)
+            {
+                throw new Exception();
+            }
+        }
+
         /// <summary>
         /// Send Message
         /// </summary>
         /// <param name="message">Message</param>
         /// <param name="flags">Send Options</param>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public void Send(byte[] message, params SendRecvOpt[] flags) {
-            if (message == null) {
+        public void Send(byte[] message, params SendRecvOpt[] flags)
+        {
+            if (message == null)
+            {
                 throw new ArgumentNullException("message");
             }
 
-            int flagsVal = 0;
-            foreach (SendRecvOpt opt in flags) {
-                flagsVal += (int)opt;
-            }
-            if (C.zmq_msg_init_size(_msg, message.Length) != 0)
-                throw new Exception();
-            Marshal.Copy(message, 0, C.zmq_msg_data(_msg), message.Length);
-            if (C.zmq_send(Ptr, _msg, flagsVal) != 0)
-                throw new Exception();
+            Send(message, 0, message.Length, flags);
         }
 
         /// <summary>

--- a/src/clrzmq/Socket.cs
+++ b/src/clrzmq/Socket.cs
@@ -466,10 +466,8 @@ namespace ZMQ {
         public byte[] Recv(byte[] message, out int size, params SendRecvOpt[] flags)
         {
             size = -1;
-
             int flagsVal = 0;
-            foreach (SendRecvOpt opt in flags)
-            {
+            foreach (SendRecvOpt opt in flags) {
                 flagsVal += (int)opt;
             }
             if (C.zmq_msg_init(_msg) != 0)
@@ -481,9 +479,7 @@ namespace ZMQ {
                     size = C.zmq_msg_size(_msg);
 
                     if (message == null || size > message.Length)
-                    {
                         message = new byte[size];
-                    }
 
                     Marshal.Copy(C.zmq_msg_data(_msg), message, 0, size);
                     C.zmq_msg_close(_msg);

--- a/src/clrzmq/Socket.cs
+++ b/src/clrzmq/Socket.cs
@@ -587,8 +587,22 @@ namespace ZMQ {
         /// <param name="flags">Receive options</param>
         /// <returns>Queue of message parts</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public Queue<byte[]> RecvAll(params SendRecvOpt[] flags) {
-            var messages = new Queue<byte[]>();
+        public Queue<byte[]> RecvAll(params SendRecvOpt[] flags)
+        {
+            return RecvAll((Queue<byte[]>)null, flags);
+        }
+
+        /// <summary>
+        /// Listen for message, retrieving all pending message parts
+        /// </summary>
+        /// <param name="messages">The queue object to put the message into</param>
+        /// <param name="flags">Receive options</param>
+        /// <returns>Queue of message parts</returns>
+        /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
+        public Queue<byte[]> RecvAll(Queue<byte[]> messages, params SendRecvOpt[] flags) {
+            if (messages == null)
+                messages = new Queue<byte[]>();
+
             messages.Enqueue(Recv(flags));
             while (RcvMore) {
                 messages.Enqueue(Recv(flags));

--- a/src/clrzmq/Socket.cs
+++ b/src/clrzmq/Socket.cs
@@ -485,7 +485,7 @@ namespace ZMQ {
                         message = new byte[size];
                     }
 
-                    Marshal.Copy(C.zmq_msg_data(_msg), message, 0, message.Length);
+                    Marshal.Copy(C.zmq_msg_data(_msg), message, 0, size);
                     C.zmq_msg_close(_msg);
                     break;
                 }

--- a/src/clrzmq/Socket.cs
+++ b/src/clrzmq/Socket.cs
@@ -533,7 +533,7 @@ namespace ZMQ {
             while (timer.ElapsedMilliseconds <= timeout) {
                 data = Recv(SendRecvOpt.NOBLOCK);
 
-                if (data == null)
+                if (data == null && timeout > 1)
                 {
                     if (iterations < 20 && ProcessorCount > 1)
                     {

--- a/src/clrzmq/Socket.cs
+++ b/src/clrzmq/Socket.cs
@@ -455,17 +455,18 @@ namespace ZMQ {
             }
         }
 
-
-
         /// <summary>
         /// Listen for message
         /// </summary>
         /// <param name="message">Message buffer</param>
+        /// <param name="size">The size of the read message</param>
         /// <param name="flags">Receive Options</param>
         /// <returns>Message</returns>
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
-        public byte[] Recv(byte[] message, params SendRecvOpt[] flags)
+        public byte[] Recv(byte[] message, out int size, params SendRecvOpt[] flags)
         {
+            size = -1;
+
             int flagsVal = 0;
             foreach (SendRecvOpt opt in flags)
             {
@@ -477,7 +478,7 @@ namespace ZMQ {
             {
                 if (C.zmq_recv(Ptr, _msg, flagsVal) == 0)
                 {
-                    int size = C.zmq_msg_size(_msg);
+                    size = C.zmq_msg_size(_msg);
 
                     if (message == null || size > message.Length)
                     {
@@ -509,7 +510,8 @@ namespace ZMQ {
         /// <exception cref="ZMQ.Exception">ZMQ Exception</exception>
         public byte[] Recv(params SendRecvOpt[] flags)
         {
-            return Recv((byte[])null, flags);
+            int size;
+            return Recv((byte[])null, out size, flags);
         }
 
         /// <summary>


### PR DESCRIPTION
Added an overload to the Socket.Recv method which has the signature `byte[] Recv(byte[] message, out int size, params SendRecvOpt[] flags)` to allow a `byte[]` to be supplied to the `Recv` function, and if it has enough space that buffer will be used instead of allocating a new `byte[]` constantly which causes a lot of pressure on the GC during high frequency messaging.

The supplied `message` parameter will only be used if two conditions are met: 
- It's not null
- It's `Length` property is larger then or equal to the size of the message

The size of the read message is also passed out through the `out int size` parameter so that in the case of using a `message` parameter which is larger then the message returned there is a way to find out how many bytes of the array that the message occupies.
