### PR TITLE
Device changes

### DIFF
--- a/src/clrzmq-ext/Device.cs
+++ b/src/clrzmq-ext/Device.cs
@@ -136,7 +136,7 @@ namespace ZMQ.ZMQDevice {
     }
 
     public class Streamer : Device {
-        public Streamer(string frontendAddr, string backendAddr, MessageProcessor msgProc)
+        public Streamer(string frontendAddr, string backendAddr)
             : base(new Socket(SocketType.PUB), new Socket(SocketType.SUB)) {
             _frontend.Bind(frontendAddr);
             _backend.Connect(backendAddr);

--- a/src/clrzmq-ext/Device.cs
+++ b/src/clrzmq-ext/Device.cs
@@ -120,7 +120,7 @@ namespace ZMQ.ZMQDevice {
     }
 
     public class Forwarder : Device {
-        public Forwarder(string frontendAddr, string backendAddr, MessageProcessor msgProc)
+        public Forwarder(string frontendAddr, string backendAddr)
             : base(new Socket(SocketType.SUB), new Socket(SocketType.PUB)) {
             _frontend.Connect(frontendAddr);
             _backend.Bind(backendAddr);

--- a/src/clrzmq-ext/Device.cs
+++ b/src/clrzmq-ext/Device.cs
@@ -34,7 +34,7 @@ namespace ZMQ.ZMQDevice {
         private readonly Thread _runningThread;
         private bool _isRunning;
 
-        private ManualResetEvent _doneEvent;
+        private readonly ManualResetEvent _doneEvent;
 
         public ManualResetEvent DoneEvent { get { return _doneEvent; } }
 

--- a/src/clrzmq-ext/Device.cs
+++ b/src/clrzmq-ext/Device.cs
@@ -112,6 +112,13 @@ namespace ZMQ.ZMQDevice {
     /// Standard Queue Device
     /// </summary>
     public class Queue : Device {
+        public Queue(Context context, string frontendAddr, string backendAddr)
+            : base(context.Socket(SocketType.PUB), context.Socket(SocketType.SUB))
+        {
+            _frontend.Bind(frontendAddr);
+            _backend.Connect(backendAddr);
+        }
+
         public Queue(string frontendAddr, string backendAddr)
             : base(new Socket(SocketType.XREP), new Socket(SocketType.XREQ)) {
             _frontend.Bind(frontendAddr);
@@ -128,6 +135,14 @@ namespace ZMQ.ZMQDevice {
     }
 
     public class Forwarder : Device {
+
+        public Forwarder(Context context, string frontendAddr, string backendAddr)
+            : base(context.Socket(SocketType.PUB), context.Socket(SocketType.SUB))
+        {
+            _frontend.Bind(frontendAddr);
+            _backend.Connect(backendAddr);
+        }
+
         public Forwarder(string frontendAddr, string backendAddr)
             : base(new Socket(SocketType.SUB), new Socket(SocketType.PUB)) {
             _frontend.Connect(frontendAddr);
@@ -143,7 +158,15 @@ namespace ZMQ.ZMQDevice {
         }
     }
 
-    public class Streamer : Device {
+    public class Streamer : Device
+    {
+        public Streamer(Context context, string frontendAddr, string backendAddr)
+            : base(context.Socket(SocketType.PUB), context.Socket(SocketType.SUB))
+        {
+            _frontend.Bind(frontendAddr);
+            _backend.Connect(backendAddr);
+        }
+
         public Streamer(string frontendAddr, string backendAddr)
             : base(new Socket(SocketType.PUB), new Socket(SocketType.SUB)) {
             _frontend.Bind(frontendAddr);
@@ -163,6 +186,14 @@ namespace ZMQ.ZMQDevice {
 
     public class AsyncReturn : Device {
         private readonly MessageProcessor _messageProcessor;
+
+        public AsyncReturn(Context context, string frontendAddr, string backendAddr, MessageProcessor msgProc)
+            : base(context.Socket(SocketType.XREP), context.Socket(SocketType.PULL))
+        {
+            _messageProcessor = msgProc;
+            _frontend.Bind(frontendAddr);
+            _backend.Bind(backendAddr);
+        }
 
         public AsyncReturn(string frontendAddr, string backendAddr, MessageProcessor msgProc)
             : base(new Socket(SocketType.XREP), new Socket(SocketType.PULL)) {


### PR DESCRIPTION
Made a few tweaks to the Device, Forwarder and Streamer classes.
- Fixed the constructor arguments to Forwarder and Streamer so they no longer take a MessageProcessor, as this was not used.
- Marked _run in Device as volatile, as this could get hoisted outside the loop otherwise and the thread would never terminate
- Added a ManualResetEvent which will be set to signaled when the device thread terminates, this is good for things like waiting in a hosting thread on a forwarder thread to finish, etc.
