### PR TITLE
Fix build on Linux using xbuild

### DIFF
--- a/src/ZeroMQ.AcceptanceTests/ZeroMQ.AcceptanceTests.csproj
+++ b/src/ZeroMQ.AcceptanceTests/ZeroMQ.AcceptanceTests.csproj
@@ -122,7 +122,7 @@
   <PropertyGroup>
     <PostBuildEvent>xcopy /y /c $(SolutionDir)..\lib\$(PlatformName)\libzmq.dll $(TargetDir)</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ZeroMQ.Perf.LatLocal/ZeroMQ.Perf.LatLocal.csproj
+++ b/src/ZeroMQ.Perf.LatLocal/ZeroMQ.Perf.LatLocal.csproj
@@ -64,7 +64,7 @@
   <PropertyGroup>
     <PostBuildEvent>xcopy /y /c $(SolutionDir)..\lib\$(PlatformName)\libzmq.dll $(TargetDir)</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ZeroMQ.Perf.LatRemote/ZeroMQ.Perf.LatRemote.csproj
+++ b/src/ZeroMQ.Perf.LatRemote/ZeroMQ.Perf.LatRemote.csproj
@@ -61,7 +61,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ZeroMQ.Perf.ThrLocal/ZeroMQ.Perf.ThrLocal.csproj
+++ b/src/ZeroMQ.Perf.ThrLocal/ZeroMQ.Perf.ThrLocal.csproj
@@ -61,7 +61,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ZeroMQ.Perf.ThrRemote/ZeroMQ.Perf.ThrRemote.csproj
+++ b/src/ZeroMQ.Perf.ThrRemote/ZeroMQ.Perf.ThrRemote.csproj
@@ -61,7 +61,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ZeroMQ.SimpleTests/ZeroMQ.SimpleTests.csproj
+++ b/src/ZeroMQ.SimpleTests/ZeroMQ.SimpleTests.csproj
@@ -109,7 +109,7 @@
   <PropertyGroup>
     <PostBuildEvent>xcopy /y /c $(SolutionDir)..\lib\$(PlatformName)\libzmq.dll $(TargetDir)</PostBuildEvent>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ZeroMQ/ZeroMQ.csproj
+++ b/src/ZeroMQ/ZeroMQ.csproj
@@ -91,7 +91,7 @@
     <Compile Include="ZmqVersionException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <Import Project="$(SolutionDir)CustomTasks.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Currently the build dies with following error:

Target ValidateSolutionConfiguration:
                Building solution configuration "Debug|x86".

```
        Target Build:
```

/home/jenkins/build/jobs/clrzmq-master_libzmq2-1_xbuild-debian/workspace/src/clrzmq.sln: error : Error building project /home/jenkins/build/jobs/clrzmq-master_libzmq2-1_xbuild-debian/workspace/src/ZeroMQ/ZeroMQ.csproj: /home/jenkins/build/jobs/clrzmq-master_libzmq2-1_xbuild-debian/workspace/src/ZeroMQ/ZeroMQ.csproj: Imported project: "/home/jenkins/build/jobs/clrzmq-master_libzmq2-1_xbuild-debian/workspace/src//.nuget/nuget.targets" does not exist.
            Task "MSBuild" execution -- FAILED
