### PR TITLE
Readme Markdown (Readme.md) Server Example Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ namespace ZMQGuide
             using (ZmqContext context = ZmqContext.Create())
             using (ZmqSocket server = context.CreateSocket(SocketType.REP))
             {
-                socket.Bind("tcp://*:5555");
+                server.Bind("tcp://*:5555");
                 
                 while (true)
                 {


### PR DESCRIPTION
changed it from "socket" to "server"
