### PR TITLE
Make project compile for .NET CF

### DIFF
--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("0.0.0.0")] 
+[assembly: AssemblyVersion("0.0.0.0")]
+#if !PocketPC
 [assembly: AssemblyFileVersion("0.0.0.0")] 
+#endif
 [assembly: AssemblyInformationalVersion("0.0.0.0 Development")] 
 [assembly: AssemblyConfiguration("Development")]

--- a/src/clrzmq/Util.cs
+++ b/src/clrzmq/Util.cs
@@ -40,7 +40,11 @@ namespace ZMQ {
         }
 
         public Exception()
+#if PocketPC
+		{
+#else
             : base(Marshal.PtrToStringAnsi(C.zmq_strerror(C.zmq_errno()))) {
+#endif
             _errno = C.zmq_errno();
         }
     }
@@ -112,7 +116,7 @@ namespace ZMQ {
                     Console.WriteLine(DecodeUUID(msg).Substring(1));
                 }
                 else {
-                    Console.WriteLine(encoding.GetString(msg));
+                    Console.WriteLine(encoding.GetString(msg, 0, msg.Length));
                 }
             }
         }

--- a/src/clrzmq/zmq_ffi.cs
+++ b/src/clrzmq/zmq_ffi.cs
@@ -26,67 +26,78 @@ using System.Runtime.InteropServices;
 
 namespace ZMQ {
     internal static class C {
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+#if PocketPC
+		private const CallingConvention cc = CallingConvention.Winapi;
+#else
+		private const CallingConvention cc = CallingConvention.Cdecl;
+#endif
+
+		[DllImport("libzmq", CallingConvention = cc)]
         public static extern IntPtr zmq_init(int io_threads);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_term(IntPtr context);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_close(IntPtr socket);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_setsockopt(IntPtr socket, int option, IntPtr optval, int optvallen);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_getsockopt(IntPtr socket, int option, IntPtr optval, IntPtr optvallen);
 
-        [DllImport("libzmq", CharSet = CharSet.Ansi,
-        CallingConvention = CallingConvention.Cdecl)]
+#if PocketPC // Because on WM we have to pass ANSI as byte arrays
+		[DllImport("libzmq", CallingConvention = CallingConvention.Winapi)]
+		public static extern int zmq_bind(IntPtr socket, byte[] addr);
+
+		[DllImport("libzmq", CallingConvention = CallingConvention.Winapi)]
+		public static extern int zmq_connect(IntPtr socket, byte[] addr);
+#else
+		[DllImport("libzmq", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern int zmq_bind(IntPtr socket, string addr);
 
-        [DllImport("libzmq", CharSet = CharSet.Ansi,
-        CallingConvention = CallingConvention.Cdecl)]
+		[DllImport("libzmq", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         public static extern int zmq_connect(IntPtr socket, string addr);
+#endif
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_recv(IntPtr socket, IntPtr msg, int flags);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_send(IntPtr socket, IntPtr msg, int flags);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern IntPtr zmq_socket(IntPtr context, int type);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_msg_close(IntPtr msg);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern IntPtr zmq_msg_data(IntPtr msg);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_msg_init(IntPtr msg);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_msg_init_size(IntPtr msg, int size);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_msg_size(IntPtr msg);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_errno();
 
-        [DllImport("libzmq", CharSet = CharSet.Ansi,
-        CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern IntPtr zmq_strerror(int errnum);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_device(int device, IntPtr inSocket, IntPtr outSocket);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern void zmq_version(IntPtr major, IntPtr minor, IntPtr patch);
 
-        [DllImport("libzmq", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("libzmq", CallingConvention = cc)]
         public static extern int zmq_poll([In, Out] ZMQPollItem[] items, int numItems, long timeout);
     }
 }


### PR DESCRIPTION
VaesionInfo.cs: CF does not have AssemblyFileVersion attribute.
Socket.cs: On CF there is no ProcessorCount property, add PocketPC architecrute to x86 regions, add Unicode-to-ANSII converion to callf of zmq_bind and zmq_connect, CF does not have Enum.GetName (add new function to get name of transport).
zmq_ffi: change DllImport attribute (CF does not support cdecl calling convention).
