### PR TITLE
Add support for ZMQ 3.2 context monitor

### DIFF
--- a/src/ZeroMQ/Interop/ContextProxy.cs
+++ b/src/ZeroMQ/Interop/ContextProxy.cs
@@ -66,6 +66,16 @@
             GC.SuppressFinalize(this);
         }
 
+        public decimal RegisterMonitor(LibZmq.MonitorFuncCallback callback)
+        {
+            return LibZmq.zmq_ctx_set_monitor(ContextHandle, callback);
+        }
+
+        public decimal UnregisterMonitor()
+        {
+            return LibZmq.zmq_ctx_set_monitor(ContextHandle, null);
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/src/ZeroMQ/Interop/EventData.cs
+++ b/src/ZeroMQ/Interop/EventData.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ZeroMQ.Interop
+{
+    [StructLayout(LayoutKind.Explicit, Pack = 4)]
+    internal struct EventData
+    {
+        [FieldOffset(0)]
+        public EventDataFileDescriptorEntry Conencted;
+        [FieldOffset(0)]
+        public EventDataErrorEntry ConenctDelayed;
+        [FieldOffset(0)]
+        public EventDataIntervalEntry ConenctRetried;
+        [FieldOffset(0)]
+        public EventDataFileDescriptorEntry Listening;
+        [FieldOffset(0)]
+        public EventDataErrorEntry BindFailed;
+        [FieldOffset(0)]
+        public EventDataFileDescriptorEntry Accepted;
+        [FieldOffset(0)]
+        public EventDataErrorEntry AcceptFailed;
+        [FieldOffset(0)]
+        public EventDataFileDescriptorEntry Closed;
+        [FieldOffset(0)]
+        public EventDataErrorEntry CloseFailed;
+        [FieldOffset(0)]
+        public EventDataFileDescriptorEntry Disconnected;
+    }
+}

--- a/src/ZeroMQ/Interop/EventDataErrorEntry.cs
+++ b/src/ZeroMQ/Interop/EventDataErrorEntry.cs
@@ -1,0 +1,19 @@
+namespace ZeroMQ.Interop
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    internal struct EventDataErrorEntry
+    {
+        private IntPtr addr;
+        public int ErrorCode;
+        public string Address
+        {
+            get
+            {
+                return Marshal.PtrToStringAnsi(this.addr);
+            }
+        }
+    }
+}

--- a/src/ZeroMQ/Interop/EventDataFileDescriptorEntry.cs
+++ b/src/ZeroMQ/Interop/EventDataFileDescriptorEntry.cs
@@ -1,0 +1,23 @@
+namespace ZeroMQ.Interop
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    internal struct EventDataFileDescriptorEntry
+    {
+        private IntPtr addr;
+#if UNIX
+        public int FileDescriptor;
+#else
+        public IntPtr FileDescriptor;
+#endif
+        public string Address
+        {
+            get
+            {
+                return Marshal.PtrToStringAnsi(this.addr);
+            }
+        }
+    }
+}

--- a/src/ZeroMQ/Interop/EventDataIntervalEntry.cs
+++ b/src/ZeroMQ/Interop/EventDataIntervalEntry.cs
@@ -1,0 +1,19 @@
+namespace ZeroMQ.Interop
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    internal struct EventDataIntervalEntry
+    {
+        private IntPtr addr;
+        public int Interval;
+        public string Address
+        {
+            get
+            {
+                return Marshal.PtrToStringAnsi(this.addr);
+            }
+        }
+    }
+}

--- a/src/ZeroMQ/Interop/LibZmq.Mono.cs
+++ b/src/ZeroMQ/Interop/LibZmq.Mono.cs
@@ -35,6 +35,7 @@ namespace ZeroMQ.Interop
 
                 zmq_ctx_get = zmq_ctx_get_v3;
                 zmq_ctx_set = zmq_ctx_set_v3;
+                zmq_ctx_set_monitor = zmq_ctx_set_monitor_v3;
 
                 zmq_unbind = zmq_unbind_v3;
                 zmq_disconnect = zmq_disconnect_v3;
@@ -52,6 +53,7 @@ namespace ZeroMQ.Interop
 
                 zmq_ctx_get = (ctx, opt) => { throw new ZmqVersionException(MajorVersion, MinorVersion, 3, 2); };
                 zmq_ctx_set = (ctx, opt, val) => { throw new ZmqVersionException(MajorVersion, MinorVersion, 3, 2); };
+                zmq_ctx_set_monitor = (ctx, opt, val) => { throw new ZmqVersionException(MajorVersion, MinorVersion, 3, 2); };
 
                 zmq_unbind = (sck, addr) => { throw new ZmqVersionException(MajorVersion, MinorVersion, 3, 2); };
                 zmq_disconnect = (sck, addr) => { throw new ZmqVersionException(MajorVersion, MinorVersion, 3, 2); };
@@ -83,12 +85,19 @@ namespace ZeroMQ.Interop
         public delegate void FreeMessageDataCallback(IntPtr data, IntPtr hint);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void MonitorFuncCallback(IntPtr socket, int eventFlags, ref EventData data);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int ZmqCtxGetProc(IntPtr context, int option);
         public static ZmqCtxGetProc zmq_ctx_get;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int ZmqCtxSetProc(IntPtr context, int option, int optval);
         public static ZmqCtxSetProc zmq_ctx_set;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int ZmqCtxSetMonitorProc(IntPtr socket, MonitorFuncCallback monitor);
+        public static ZmqCtxSetMonitorProc zmq_ctx_set_monitor;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         public delegate int ZmqBindProc(IntPtr socket, string addr);
@@ -129,6 +138,9 @@ namespace ZeroMQ.Interop
 
         [DllImport(LibraryName, EntryPoint = "zmq_ctx_set", CallingConvention = CallingConvention.Cdecl)]
         public static extern int zmq_ctx_set_v3(IntPtr context, int option, int optval);
+
+        [DllImport(LibraryName, EntryPoint = "zmq_ctx_set_monitor", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int zmq_ctx_set_monitor_v3(IntPtr socket, MonitorFuncCallback monitor);
 
         [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int zmq_close(IntPtr socket);

--- a/src/ZeroMQ/Interop/LibZmq.NET.cs
+++ b/src/ZeroMQ/Interop/LibZmq.NET.cs
@@ -50,6 +50,7 @@ namespace ZeroMQ.Interop
                 zmq_ctx_destroy = NativeLib.GetUnmanagedFunction<ZmqCtxDestroyProc>("zmq_ctx_destroy");
                 zmq_ctx_get = NativeLib.GetUnmanagedFunction<ZmqCtxGetProc>("zmq_ctx_get");
                 zmq_ctx_set = NativeLib.GetUnmanagedFunction<ZmqCtxSetProc>("zmq_ctx_set");
+                zmq_ctx_set_monitor = NativeLib.GetUnmanagedFunction<ZmqCtxSetMonitorProc>("zmq_ctx_set_monitor");
 
                 zmq_unbind = NativeLib.GetUnmanagedFunction<ZmqBindProc>("zmq_unbind");
                 zmq_disconnect = NativeLib.GetUnmanagedFunction<ZmqConnectProc>("zmq_disconnect");
@@ -114,6 +115,9 @@ namespace ZeroMQ.Interop
         public delegate void FreeMessageDataCallback(IntPtr data, IntPtr hint);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void MonitorFuncCallback(IntPtr socket, int eventFlags, ref EventData data);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate IntPtr ZmqCtxNewProc();
         public static ZmqCtxNewProc zmq_ctx_new;
 
@@ -131,6 +135,10 @@ namespace ZeroMQ.Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int ZmqCtxSetProc(IntPtr context, int option, int optval);
         public static ZmqCtxSetProc zmq_ctx_set;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate int ZmqCtxSetMonitorProc(IntPtr socket, MonitorFuncCallback monitor);
+        public static ZmqCtxSetMonitorProc zmq_ctx_set_monitor;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int ZmqSetSockOptProc(IntPtr socket, int option, IntPtr optval, int optvallen);

--- a/src/ZeroMQ/Interop/SocketProxy.cs
+++ b/src/ZeroMQ/Interop/SocketProxy.cs
@@ -5,14 +5,17 @@
 
     internal class SocketProxy : IDisposable
     {
+        private readonly Action<IntPtr> socketClosed;
+
         // From options.hpp: unsigned char identity [256];
         private const int MaxBinaryOptionSize = 255;
 
         private IntPtr _message;
         private bool _disposed;
 
-        public SocketProxy(IntPtr socketHandle)
+        public SocketProxy(IntPtr socketHandle, Action<IntPtr> socketClosed)
         {
+            this.socketClosed = socketClosed;
             if (socketHandle == IntPtr.Zero)
             {
                 throw new ArgumentException("Socket handle must be a valid pointer.", "socketHandle");
@@ -58,7 +61,8 @@
             }
 
             int rc = LibZmq.zmq_close(SocketHandle);
-
+            socketClosed(SocketHandle);
+            
             SocketHandle = IntPtr.Zero;
 
             return rc;

--- a/src/ZeroMQ/MonitorEvent.cs
+++ b/src/ZeroMQ/MonitorEvent.cs
@@ -1,0 +1,58 @@
+namespace ZeroMQ
+{
+    using System;
+
+    [Flags]
+    internal enum MonitorEvent
+    {
+        /// <summary>
+        /// connection established
+        /// </summary>
+        CONNECTED = 1,
+
+        /// <summary>
+        /// synchronous connect failed, it's being polled
+        /// </summary>
+        CONNECT_DELAYED = 2,
+
+        /// <summary>
+        /// asynchronous connect / reconnection attempt
+        /// </summary>
+        CONNECT_RETRIED = 4,
+
+        /// <summary>
+        /// socket bound to an address, ready to accept connections
+        /// </summary>
+        LISTENING = 8,
+
+        /// <summary>
+        /// socket could not bind to an address
+        /// </summary>
+        BIND_FAILED = 16,
+
+        /// <summary>
+        /// connection accepted to bound interface
+        /// </summary>
+        ACCEPTED = 32,
+
+        /// <summary>
+        /// could not accept client connection
+        /// </summary>
+        ACCEPT_FAILED = 64,
+
+        /// <summary>
+        /// connection closed
+        /// </summary>
+        CLOSED = 128,
+
+        /// <summary>
+        /// connection couldn't be closed
+        /// </summary>
+        CLOSE_FAILED = 256,
+
+        /// <summary>
+        /// broken session
+        /// </summary>
+        DISCONNECTED = 512,
+    }
+}

--- a/src/ZeroMQ/ZeroMQ.csproj
+++ b/src/ZeroMQ/ZeroMQ.csproj
@@ -51,6 +51,10 @@
     <Compile Include="DuplexSocket.cs" />
     <Compile Include="Devices\IDevice.cs" />
     <Compile Include="Interop\ErrorDetails.cs" />
+    <Compile Include="Interop\EventData.cs" />
+    <Compile Include="Interop\EventDataErrorEntry.cs" />
+    <Compile Include="Interop\EventDataFileDescriptorEntry.cs" />
+    <Compile Include="Interop\EventDataIntervalEntry.cs" />
     <Compile Include="Interop\LibZmq.Mono.cs" />
     <Compile Include="Interop\Platform.Mono.cs" />
     <Compile Include="Interop\Platform.NET.cs" />
@@ -62,6 +66,7 @@
     <Compile Include="Interop\ManifestResource.cs" />
     <Compile Include="Interop\SafeLibraryHandle.cs" />
     <Compile Include="Interop\UnmanagedLibrary.cs" />
+    <Compile Include="MonitorEvent.cs" />
     <Compile Include="RouterBehavior.cs" />
     <Compile Include="TcpKeepaliveBehaviour.cs" />
     <Compile Include="ZmqMessage.cs" />
@@ -88,6 +93,11 @@
     <Compile Include="SocketType.cs" />
     <Compile Include="ZmqContext.cs" />
     <Compile Include="ZmqException.cs" />
+    <Compile Include="ZmqMonitor.cs" />
+    <Compile Include="ZmqMonitorErrorEventArgs.cs" />
+    <Compile Include="ZmqMonitorEventArgs.cs" />
+    <Compile Include="ZmqMonitorFileDescriptorEventArgs.cs" />
+    <Compile Include="ZmqMonitorIntervalEventArgs.cs" />
     <Compile Include="ZmqSocket.cs" />
     <Compile Include="ZmqSocketException.cs" />
     <Compile Include="ZmqVersion.cs" />

--- a/src/ZeroMQ/ZmqMonitor.cs
+++ b/src/ZeroMQ/ZmqMonitor.cs
@@ -1,0 +1,146 @@
+namespace ZeroMQ
+{
+    using System;
+    using System.Collections.Generic;
+    using ZeroMQ.Interop;
+
+    /// <summary>
+    /// A socket monitoring object.
+    /// </summary>
+    /// <remarks>
+    /// CAUTION: ZmqMonitor is intended for monitoring infrastructure /
+    /// operations concerns only - NOT BUSINESS LOGIC. An event is a representation of
+    /// something that happened - you cannot change the past, but only react to them.
+    /// The implementation is also only concerned with a single session. No state of
+    /// peers, other sessions etc. are tracked - this will only pollute internals and
+    /// is the responsibility of application authors to either implement or correlate
+    /// in another datastore. Monitor events are exceptional conditions and are thus
+    /// not directly in the messaging critical path. However, still be careful with
+    /// what you're doing in the callback function as excess time spent in the handler
+    /// will block the socket's application thread.
+    /// </remarks>
+    public class ZmqMonitor : IDisposable
+    {
+        private readonly ZmqContext context;
+
+        private readonly Dictionary<MonitorEvent, Action<ZmqSocket, EventData>> eventHandler = new Dictionary<MonitorEvent, Action<ZmqSocket, EventData>>();
+
+        private bool _disposed;
+
+        internal ZmqMonitor(ZmqContext context)
+        {
+            this.context = context;
+
+            this.eventHandler.Add(MonitorEvent.CONNECTED, (socket, data) => this.InvokeEvent(this.Connected, () => this.CreateEventArgs(socket, data.Conencted)));
+            this.eventHandler.Add(MonitorEvent.CONNECT_DELAYED, (socket, data) => this.InvokeEvent(this.ConnectDelayed, () => this.CreateEventArgs(socket, data.ConenctDelayed)));
+            this.eventHandler.Add(MonitorEvent.CONNECT_RETRIED, (socket, data) => this.InvokeEvent(this.ConnectRetried, () => this.CreateEventArgs(socket, data.ConenctRetried)));
+
+            this.eventHandler.Add(MonitorEvent.LISTENING, (socket, data) => this.InvokeEvent(this.Listening, () => this.CreateEventArgs(socket, data.Listening)));
+            this.eventHandler.Add(MonitorEvent.BIND_FAILED, (socket, data) => this.InvokeEvent(this.BindFailed, () => this.CreateEventArgs(socket, data.BindFailed)));
+
+            this.eventHandler.Add(MonitorEvent.ACCEPTED, (socket, data) => this.InvokeEvent(this.Accepted, () => this.CreateEventArgs(socket, data.Accepted)));
+            this.eventHandler.Add(MonitorEvent.ACCEPT_FAILED, (socket, data) => this.InvokeEvent(this.AcceptFailed, () => this.CreateEventArgs(socket, data.AcceptFailed)));
+
+            this.eventHandler.Add(MonitorEvent.CLOSED, (socket, data) => this.InvokeEvent(this.Closed, () => this.CreateEventArgs(socket, data.Closed)));
+            this.eventHandler.Add(MonitorEvent.CLOSE_FAILED, (socket, data) => this.InvokeEvent(this.CloseFailed, () => this.CreateEventArgs(socket, data.CloseFailed)));
+            this.eventHandler.Add(MonitorEvent.DISCONNECTED, (socket, data) => this.InvokeEvent(this.Disconnected, () => this.CreateEventArgs(socket, data.Disconnected)));
+        }
+
+        /// <summary>
+        /// Occurs when a new connection established.
+        /// </summary>
+        public event EventHandler<ZmqMonitorFileDescriptorEventArgs> Connected;
+
+        /// <summary>
+        /// Occurs when a synchronous connect failed, and it's being polled.
+        /// </summary>
+        public event EventHandler<ZmqMonitorErrorEventArgs> ConnectDelayed;
+
+        /// <summary>
+        /// Occurs when a asynchronous connect / reconnection attempt.
+        /// </summary>
+        public event EventHandler<ZmqMonitorIntervalEventArgs> ConnectRetried;
+
+        /// <summary>
+        /// Occurs when a socket bound to an address, ready to accept connections.
+        /// </summary>
+        public event EventHandler<ZmqMonitorFileDescriptorEventArgs> Listening;
+
+        /// <summary>
+        /// Occurs when a socket could not bind to an address.
+        /// </summary>
+        public event EventHandler<ZmqMonitorErrorEventArgs> BindFailed;
+
+        /// <summary>
+        /// Occurs when connection accepted to bound interface.
+        /// </summary>
+        public event EventHandler<ZmqMonitorFileDescriptorEventArgs> Accepted;
+
+        /// <summary>
+        /// Occurs when a socket could not accept client connection.
+        /// </summary>
+        public event EventHandler<ZmqMonitorErrorEventArgs> AcceptFailed;
+
+        /// <summary>
+        /// Occurs when a connection was closed.
+        /// </summary>
+        public event EventHandler<ZmqMonitorFileDescriptorEventArgs> Closed;
+
+        /// <summary>
+        /// Occurs when a connection couldn't be closed.
+        /// </summary>
+        public event EventHandler<ZmqMonitorErrorEventArgs> CloseFailed;
+
+        /// <summary>
+        /// Occurs when a session is broken.
+        /// </summary>
+        public event EventHandler<ZmqMonitorFileDescriptorEventArgs> Disconnected;
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        internal void OnMonitor(ZmqSocket socket, int ev, ref EventData data)
+        {
+            this.eventHandler[(MonitorEvent)ev](socket, data);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    this.context.MonitorDisposed(this);
+                }
+            }
+
+            _disposed = true;
+        }
+
+        private ZmqMonitorFileDescriptorEventArgs CreateEventArgs(ZmqSocket socket, EventDataFileDescriptorEntry data)
+        {
+            return new ZmqMonitorFileDescriptorEventArgs(socket, data.Address, data.FileDescriptor);
+        }
+
+        private ZmqMonitorErrorEventArgs CreateEventArgs(ZmqSocket socket, EventDataErrorEntry data)
+        {
+            return new ZmqMonitorErrorEventArgs(socket, data.Address, data.ErrorCode);
+        }
+
+        private ZmqMonitorIntervalEventArgs CreateEventArgs(ZmqSocket socket, EventDataIntervalEntry data)
+        {
+            return new ZmqMonitorIntervalEventArgs(socket, data.Address, data.Interval);
+        }
+
+        private void InvokeEvent<T>(EventHandler<T> handler, Func<T> create) where T : EventArgs
+        {
+            if (handler != null)
+            {
+                handler(this.context, create());
+            }
+        }
+    }
+}

--- a/src/ZeroMQ/ZmqMonitorErrorEventArgs.cs
+++ b/src/ZeroMQ/ZmqMonitorErrorEventArgs.cs
@@ -1,0 +1,19 @@
+namespace ZeroMQ
+{
+    /// <summary>
+    /// Provides data for <see cref="ZmqMonitor.ConnectDelayed"/>, <see cref="ZmqMonitor.AcceptFailed"/>, <see cref="ZmqMonitorErrorEventArgs"/> and <see cref="ZmqMonitor.BindFailed"/> events.
+    /// </summary>
+    public class ZmqMonitorErrorEventArgs : ZmqMonitorEventArgs
+    {
+        public ZmqMonitorErrorEventArgs(ZmqSocket socket, string address, int errorCode)
+            : base(socket, address)
+        {
+            this.ErrorCode = errorCode;
+        }
+
+        /// <summary>
+        /// Gets error code number.
+        /// </summary>
+        public int ErrorCode { get; private set; }
+    }
+}

--- a/src/ZeroMQ/ZmqMonitorEventArgs.cs
+++ b/src/ZeroMQ/ZmqMonitorEventArgs.cs
@@ -1,0 +1,26 @@
+namespace ZeroMQ
+{
+    using System;
+
+    /// <summary>
+    /// A base class for the all ZmqMonitor events.
+    /// </summary>
+    public class ZmqMonitorEventArgs : EventArgs
+    {
+        public ZmqMonitorEventArgs(ZmqSocket socket, string address)
+        {
+            this.Socket = socket;
+            this.Address = address;
+        }
+
+        /// <summary>
+        /// Gets socket that triggered the event.
+        /// </summary>
+        public ZmqSocket Socket { get; private set; }
+
+        /// <summary>
+        /// Gets peer address.
+        /// </summary>
+        public string Address { get; private set; }
+    }
+}

--- a/src/ZeroMQ/ZmqMonitorFileDescriptorEventArgs.cs
+++ b/src/ZeroMQ/ZmqMonitorFileDescriptorEventArgs.cs
@@ -1,0 +1,29 @@
+namespace ZeroMQ
+{
+    using System;
+
+    /// <summary>
+    /// Provides data for <see cref="ZmqMonitor.Connected"/>, <see cref="ZmqMonitor.Listening"/>, <see cref="ZmqMonitor.Accepted"/>, <see cref="ZmqMonitor.Closed"/> and <see cref="ZmqMonitor.Disconnected"/> events.
+    /// </summary>
+    public class ZmqMonitorFileDescriptorEventArgs : ZmqMonitorEventArgs
+    {
+#if UNIX
+        public ZmqMonitorFileDescriptorEventArgs(ZmqSocket socket, string address, int fileDescriptor)
+#else
+        public ZmqMonitorFileDescriptorEventArgs(ZmqSocket socket, string address, IntPtr fileDescriptor)
+#endif
+            : base(socket, address)
+        {
+            this.FileDescriptor = fileDescriptor;
+        }
+
+        /// <summary>
+        /// Gets socket descriptor.
+        /// </summary>
+#if UNIX
+        public int FileDescriptor { get; private set; }
+#else
+        public IntPtr FileDescriptor { get; private set; }
+#endif
+    }
+}

--- a/src/ZeroMQ/ZmqMonitorIntervalEventArgs.cs
+++ b/src/ZeroMQ/ZmqMonitorIntervalEventArgs.cs
@@ -1,0 +1,19 @@
+namespace ZeroMQ
+{
+    /// <summary>
+    /// Provides data for <see cref="ZmqMonitor.ConnectRetried"/> event.
+    /// </summary>
+    public class ZmqMonitorIntervalEventArgs : ZmqMonitorEventArgs
+    {
+        public ZmqMonitorIntervalEventArgs(ZmqSocket socket, string address, int interval)
+            : base(socket, address)
+        {
+            this.Interval = interval;
+        }
+
+        /// <summary>
+        /// Gets computed reconnect interval.
+        /// </summary>
+        public int Interval { get; private set; }
+    }
+}


### PR DESCRIPTION
Some issues still not solved:
- no acceptance tests
- not tested under mono (EventDataFileDescriptorEntry.cs, ZmqMonitorFileDescriptorEventArgs.cs and LibZmq.Mono.cs)
- some events not properly worked, but it is not related to the .NET (see https://github.com/zeromq/zeromq3-x/pull/23 )
