### PR TITLE
Omit 'is obsolete' warnings.

### DIFF
--- a/src/ZeroMQ/Devices/QueueDevice.cs
+++ b/src/ZeroMQ/Devices/QueueDevice.cs
@@ -15,12 +15,12 @@
         /// <summary>
         /// The frontend <see cref="SocketType"/> for a queue device.
         /// </summary>
-        public const SocketType FrontendType = SocketType.XREP;
+        public const SocketType FrontendType = SocketType.ROUTER;
 
         /// <summary>
         /// The backend <see cref="SocketType"/> for a queue device.
         /// </summary>
-        public const SocketType BackendType = SocketType.XREQ;
+        public const SocketType BackendType = SocketType.DEALER;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QueueDevice"/> class that will run in a

--- a/src/ZeroMQ/ZmqSocket.cs
+++ b/src/ZeroMQ/ZmqSocket.cs
@@ -16,8 +16,10 @@
 
         private static readonly int ProcessorCount = Environment.ProcessorCount;
 
+#pragma warning disable 618
         private static readonly SocketOption ReceiveHwmOpt = ZmqVersion.Current.IsAtLeast(LatestVersion) ? SocketOption.RCVHWM : SocketOption.HWM;
         private static readonly SocketOption SendHwmOpt = ZmqVersion.Current.IsAtLeast(LatestVersion) ? SocketOption.SNDHWM : SocketOption.HWM;
+#pragma warning restore 618
 
         private readonly SocketProxy _socketProxy;
 


### PR DESCRIPTION
Annoying while developing.
This adds a comfort for internal development and no affect the external.
Just suggestion.
