### PR TITLE
Fix garbage collected delegate exception.

### DIFF
--- a/src/ZeroMQ/Interop/ContextProxy.cs
+++ b/src/ZeroMQ/Interop/ContextProxy.cs
@@ -18,7 +18,10 @@
 
         public IntPtr ContextHandle { get; private set; }
 
-        public bool MonitorRegistered { get; private set; }
+        public bool MonitorRegistered
+        {
+            get { return _callback != null; }
+        }
 
         public int Initialize()
         {
@@ -69,14 +72,14 @@
 
         public int RegisterMonitor(LibZmq.MonitorFuncCallback callback)
         {
-            MonitorRegistered = true;
             _callback = callback;
+
             return LibZmq.zmq_ctx_set_monitor(ContextHandle, _callback);
         }
 
         public int UnregisterMonitor()
         {
-            MonitorRegistered = false;
+            _callback = null;
 
             return LibZmq.zmq_ctx_set_monitor(ContextHandle, null);
         }

--- a/src/ZeroMQ/Interop/ContextProxy.cs
+++ b/src/ZeroMQ/Interop/ContextProxy.cs
@@ -4,6 +4,11 @@
 
     internal class ContextProxy : IDisposable
     {
+        /// <summary>
+        /// This will prevent the garbage collector from collecting the callback delegate during the execution.
+        /// </summary>
+        private LibZmq.MonitorFuncCallback _callback;
+
         private bool _disposed;
 
         ~ContextProxy()
@@ -65,8 +70,8 @@
         public int RegisterMonitor(LibZmq.MonitorFuncCallback callback)
         {
             MonitorRegistered = true;
-
-            return LibZmq.zmq_ctx_set_monitor(ContextHandle, callback);
+            _callback = callback;
+            return LibZmq.zmq_ctx_set_monitor(ContextHandle, _callback);
         }
 
         public int UnregisterMonitor()


### PR DESCRIPTION
John, i found a problem.

I got **NullReferenceException** when use monitor.
Visual studio says: A call has been made on a garbage collected delegate.
To fix this **ContextProxy** should keep reference to the callback delegate.

Here is a similar discussion on [msdn](http://social.msdn.microsoft.com/Forums/en-US/clr/thread/a04b7a0e-5994-4fef-a4b5-790d081804b8/) and [stackoverflow](http://stackoverflow.com/questions/6193711/call-has-been-made-on-garbage-collected-delegate-in-c).

It can be easely reproduced: by adding **GC.Collect()** right after **Context.CreateMonitor()** call.

Should I provide a test scenario for this case?
