### PR TITLE
ContextHandle getter within ZmqContext

### DIFF
--- a/src/ZeroMQ/ZmqContext.cs
+++ b/src/ZeroMQ/ZmqContext.cs
@@ -70,6 +70,14 @@
         }
 
         /// <summary>
+        /// Gets the native 0MQ context.
+        /// </summary>
+        public IntPtr ContextHandle
+        {
+            get { return _contextProxy.ContextHandle; }
+        }
+
+        /// <summary>
         /// Create a <see cref="ZmqContext"/> instance.
         /// </summary>
         /// <returns>A <see cref="ZmqContext"/> instance with the default thread pool size (1).</returns>


### PR DESCRIPTION
I created a getter for ContextHandle within ZmqContext class.
This will allow sharing the same context with native libraries using 0MQ C API, so that we can centralize a single 0MQ context within the same process, which is a requirement for things like inproc transport.
