### PR TITLE
ClearSockets now calls CreatePollItems

### DIFF
--- a/src/ZeroMQ/Poller.cs
+++ b/src/ZeroMQ/Poller.cs
@@ -120,6 +120,7 @@
         public void ClearSockets()
         {
             _pollableSockets.Clear();
+            CreatePollItems();
         }
 
         /// <summary>


### PR DESCRIPTION
ClearSockets() now calls CreatePollItems() to rebuild the internal poll
items array for passing to libzmq. This fixes an issues of adding and
clearing the same number of sockets from the poller before the next
poll.
