### PR TITLE
Support for ZMQ_XPUB_VERBOSE

### DIFF
--- a/src/ZeroMQ/SocketOption.cs
+++ b/src/ZeroMQ/SocketOption.cs
@@ -42,5 +42,6 @@
         TCP_KEEPALIVE_IDLE = 36,
         TCP_KEEPALIVE_INTVL = 37,
         TCP_ACCEPT_FILTER = 38,
+        XPUB_VERBOSE = 40,
     }
 }

--- a/src/ZeroMQ/XpubVerboseBehavior.cs
+++ b/src/ZeroMQ/XpubVerboseBehavior.cs
@@ -1,0 +1,21 @@
+﻿
+namespace ZeroMQ
+{
+    /// <summary>
+    /// Specifies <see cref="SocketType.XPUB"/> socket behavior on new subscriptions
+    /// and unsubscriptions.
+    /// </summary>
+    public enum XpubVerboseBehaviour
+    {
+        /// <summary>
+        /// Only pass new subscription messages upstream.
+        /// </summary>
+        NewSubscriptionsOnly = 0,
+
+        /// <summary>
+        /// Pass all subscriptioon messages upstream
+        /// enabling blocking sends.
+        /// </summary>
+        AllSubscriptions = 1,
+    }
+}

--- a/src/ZeroMQ/ZeroMQ.csproj
+++ b/src/ZeroMQ/ZeroMQ.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Monitoring\MonitorSocketExtensions.cs" />
     <Compile Include="RouterBehavior.cs" />
     <Compile Include="TcpKeepaliveBehaviour.cs" />
+    <Compile Include="XpubVerboseBehavior.cs" />
     <Compile Include="ZmqMessage.cs" />
     <Compile Include="Poller.cs" />
     <Compile Include="SendReceiveExtensions.cs" />

--- a/src/ZeroMQ/ZmqSocket.cs
+++ b/src/ZeroMQ/ZmqSocket.cs
@@ -1,7 +1,7 @@
 ﻿namespace ZeroMQ
 {
-    using System;
     using Interop;
+    using System;
 
     /// <summary>
     /// Sends and receives messages across various transports to potentially multiple endpoints
@@ -306,7 +306,7 @@
         {
             set { ZmqVersion.OnlyIfAtLeast(LatestVersion, () => SetSocketOption(SocketOption.ROUTER_BEHAVIOR, (int)value)); }
         }
-        
+
         /// <summary>
         /// Gets or sets the override value for the SO_KEEPALIVE TCP socket option. (where supported by OS). (Default = -1, OS default).
         /// </summary>
@@ -358,6 +358,19 @@
         {
             get { return ZmqVersion.OnlyIfAtLeast(LatestVersion, () => GetSocketOptionInt32(SocketOption.TCP_KEEPALIVE_INTVL)); }
             set { ZmqVersion.OnlyIfAtLeast(LatestVersion, () => SetSocketOption(SocketOption.TCP_KEEPALIVE_INTVL, value)); }
+        }
+
+        /// <summary>
+        /// Sets the xpub verbose behavior on the current socket.(Default = <see cref="ZeroMQ.XpubVerboseBehaviour.NewSubscriptionsOnly"/>).
+        /// Only applicable to the <see cref="ZeroMQ.SocketType.XPUB"/> socket type.
+        /// </summary>
+        /// <exception cref="ZmqVersionException">This socket option was used in ZeroMQ 2.x or lower.</exception>
+        /// <exception cref="ZmqSocketException">An error occurred when setting the socket option.</exception>
+        /// <exception cref="ObjectDisposedException">The <see cref="ZmqSocket"/> has been closed.</exception>
+        /// <remarks>Not supported in 0MQ version 2.</remarks>
+        public XpubVerboseBehaviour XPubVerbose
+        {
+            set { ZmqVersion.OnlyIfAtLeast(LatestVersion, () => SetSocketOption(SocketOption.XPUB_VERBOSE, (int)value)); }
         }
 
         /// <summary>


### PR DESCRIPTION
Update to add support for the ZMQ_XPUB_VERBOSE socket option
