### PR TITLE
Add Pop method to ZmqMessage

### DIFF
--- a/src/ZeroMQ/ZmqMessage.cs
+++ b/src/ZeroMQ/ZmqMessage.cs
@@ -197,6 +197,25 @@
         }
 
         /// <summary>
+        /// Pops a <see cref="Frame"/> off the front of the message.
+        /// </summary>
+        /// <returns>The first <see cref="Frame"/> in the message or <c>null</c> if the message is empty.</returns>
+        public Frame Pop()
+        {
+            Frame result = null;
+
+            if (_frames.Count > 0)
+            {
+                result = _frames[0];
+                _frames.RemoveAt(0);
+            }
+
+            NormalizeFrames();
+
+            return result;
+        }
+
+        /// <summary>
         /// Pushes <paramref name="frame"/> plus an empty frame to the front
         /// of the message.
         /// </summary>


### PR DESCRIPTION
I've added a Pop method to ZmqMessage that is equivalent to zmsg_pop(). We need this method since Unwrap also deletes the second frame when it's empty and this is sometimes unwanted e.g. when the payload frame after the header is null but we still want to submit the empty payload frame to the higher layers.
