### PR TITLE
Change to avoid Stopwatch allocation if timeout for PollNonBlocking is 0

### DIFF
--- a/src/ZeroMQ/Poller.cs
+++ b/src/ZeroMQ/Poller.cs
@@ -147,7 +147,7 @@
         {
             return (int)timeout.TotalMilliseconds == Timeout.Infinite
                 ? PollBlocking()
-                : PollNonBlocking(timeout);
+                : (int)timeout.TotalMilliseconds == 0 ? PollNonBlocking() : PollNonBlocking(timeout);
         }
 
         /// <summary>
@@ -208,6 +208,21 @@
                 remainingTimeout -= (int)elapsed.ElapsedMilliseconds;
             }
             while (remainingTimeout >= 0);
+
+            return readyCount;
+        }
+
+        private int PollNonBlocking()
+        {
+            CreatePollItems();
+
+            var readyCount = Poll(0);
+            if (readyCount >= 0 || ErrorProxy.ContextWasTerminated)
+            {
+                return readyCount;
+            }
+
+            ContinueIfInterrupted();
 
             return readyCount;
         }


### PR DESCRIPTION
We recently noticed issues with memory usage and increased GC pressure with high traffic under clrzmq. We traced the issue to the fact that the Poller's PollNonBlocking(timeout) method allocates a new Stopwatch with every iteration of the loop. With the timeout set to 0 this allocation is unnecessary. The attached change doesn't initialize a Stopwatch if the timeout for PollNonBlocking is set to 0.
